### PR TITLE
LPS-168762 - HR_442 Skip to content link not working on the roles page

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-admin/src/templates/portlet.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-admin/src/templates/portlet.ftl
@@ -2,8 +2,16 @@
 
 <#if portletDisplay.isStateMax()>
 	<@liferay.control_menu />
+
+	<main id="main-content">
+		<@displayPortlet/>
+	</main>
+<#else>
+	<@displayPortlet/>
 </#if>
 
-<section class="portlet" id="portlet_${htmlUtil.escapeAttribute(portletDisplay.getId())}">
-	${portletDisplay.writeContent(writer)}
-</section>
+<#macro displayPortlet>
+	<section class="portlet" id="portlet_${htmlUtil.escapeAttribute(portletDisplay.getId())}">
+		${portletDisplay.writeContent(writer)}
+	</section>
+</#macro>

--- a/portal-web/docroot/layouttpl/standard/max.ftl
+++ b/portal-web/docroot/layouttpl/standard/max.ftl
@@ -1,4 +1,4 @@
-<div class="columns-max" id="main-content" role="main">
+<div class="columns-max" #if(!$layout.isTypeControlPanel())id="main-content" role="main"#end>
 	<div class="portlet-layout row">
 		<div class="col-md-12 portlet-column portlet-column-only" id="column-1">
 			${processor.processMax()}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-168762

The main issues with skip to content take place in the control panel. When in the control panel portlets are in a maximized state so we can move the main content in this scenario to wrap the portlet. This way the control panel is not included inside the main-content section.

The check in max.ftl to see if it is a control panel layout may look a little odd. This is because it's written in velocity even though the template should be freemarker. This is being incorrectly interpreted as a freemarker template so I've created an issue for that here: https://issues.liferay.com/browse/LPS-183098

It's important to only apply this to control panel since the max.ftl template is also used in the full page application template which does not use the admin theme.

This fix will result in skip to main content taking the user directly to the portlet skipping the control panel as seen in the screenshot:
![Screenshot 2023-04-27 at 12 15 10 PM](https://user-images.githubusercontent.com/1609196/234903372-995f8d4d-69a8-4546-9409-ae924c3a33cf.png)


cc: @veroglez @marcoscv-work 