### PR TITLE
LPS-168108 Restores focus to search button when closed in mobile version

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -19,7 +19,7 @@ import {LinkOrButton} from '@clayui/shared';
 import {ManagementToolbar as FrontendManagementToolbar} from 'frontend-js-components-web';
 import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
-import React, {useMemo, useState} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 
 import normalizeDropdownItems from '../normalize_dropdown_items';
 import ActionControls from './ActionControls';
@@ -98,6 +98,16 @@ function ManagementToolbar({
 		activeViewType?.label
 	);
 
+	const searchButtonRef = useRef();
+
+	useEffect(() => {
+		if (searchMobile) {
+			const searchButton = searchButtonRef.current;
+
+			return () => searchButton?.focus();
+		}
+	}, [searchMobile]);
+
 	return (
 		<FeatureFlagContext.Provider
 			value={{showDesignImprovements: showDesignImprovementsFF}}
@@ -168,6 +178,7 @@ function ManagementToolbar({
 					{!active && showSearch && (
 						<SearchControls.ShowMobileButton
 							disabled={disabled}
+							ref={searchButtonRef}
 							setSearchMobile={setSearchMobile}
 						/>
 					)}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SearchControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SearchControls.js
@@ -116,22 +116,25 @@ const SearchControls = ({
 	);
 };
 
-const ShowMobileButton = ({disabled, setSearchMobile}) => {
-	return (
-		<ManagementToolbar.Item className="navbar-breakpoint-d-none">
-			<ClayButtonWithIcon
-				aria-haspopup="true"
-				aria-label={Liferay.Language.get('open-search')}
-				className="nav-link nav-link-monospaced"
-				disabled={disabled}
-				displayType="unstyled"
-				onClick={() => setSearchMobile(true)}
-				symbol="search"
-				title={Liferay.Language.get('open-search')}
-			/>
-		</ManagementToolbar.Item>
-	);
-};
+const ShowMobileButton = React.forwardRef(
+	({disabled, setSearchMobile}, ref) => {
+		return (
+			<ManagementToolbar.Item className="navbar-breakpoint-d-none">
+				<ClayButtonWithIcon
+					aria-haspopup="true"
+					aria-label={Liferay.Language.get('open-search')}
+					className="nav-link nav-link-monospaced"
+					disabled={disabled}
+					displayType="unstyled"
+					onClick={() => setSearchMobile(true)}
+					ref={ref}
+					symbol="search"
+					title={Liferay.Language.get('open-search')}
+				/>
+			</ManagementToolbar.Item>
+		);
+	}
+);
 
 SearchControls.ShowMobileButton = ShowMobileButton;
 


### PR DESCRIPTION
This PR is a follow-up to the PR as [I commented on the ticket](https://issues.liferay.com/browse/LPS-168108?focusedCommentId=2906008&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-2906008), this accessibility behavior was just missing for us to close the ticket.

To test the behavior:

1. Go to Content Data > Web Content
2. Zoom the page 400%
3. Navigate to the search button and press enter
4. Navigate to the close button and see the focus move back to the open search button