### PR TITLE
LPS-184541 - Unable to activate feature flags due to JS error.

### DIFF
--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/display/FeatureFlagsManagementToolbarDisplayContext.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/display/FeatureFlagsManagementToolbarDisplayContext.java
@@ -132,16 +132,14 @@ public class FeatureFlagsManagementToolbarDisplayContext
 		DropdownItemList dropdownItemList = new DropdownItemList();
 
 		for (Filter filter : FILTERS) {
-			dropdownItemList.addGroup(
-				dropdownGroupItem -> dropdownGroupItem.setLabel(
-					langGet(filter.getLabel())));
+			DropdownItemList filterDropdownItemList = new DropdownItemList();
 
 			String currentValue = filter.getCurrentValue(httpServletRequest);
 
 			PortletURL portletURL = getPortletURL();
 
 			for (String value : filter.getValues()) {
-				dropdownItemList.add(
+				filterDropdownItemList.add(
 					dropdownItem -> {
 						dropdownItem.setActive(
 							Objects.equals(currentValue, value));
@@ -150,6 +148,12 @@ public class FeatureFlagsManagementToolbarDisplayContext
 						dropdownItem.setLabel(langGet(value));
 					});
 			}
+
+			dropdownItemList.addGroup(
+				dropdownGroupItem -> {
+					dropdownGroupItem.setDropdownItems(filterDropdownItemList);
+					dropdownGroupItem.setLabel(langGet(filter.getLabel()));
+				});
 		}
 
 		return dropdownItemList;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-184541

A JS error is thrown when a dropdown item group does not contain subitems. This results in management toolbar not being shown and feature flags not being able to be toggled.

cc: @drewbrokke