### PR TITLE
LPS-185093 - Investigate InstanceSettings.testcase

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/InstanceSettings.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/InstanceSettings.testcase
@@ -16,10 +16,11 @@ definition {
 		var testPortalInstance = PropsUtil.get("test.portal.instance");
 
 		if (${testPortalInstance} == "true") {
-			PortalInstances.tearDownCP();
+			PortalSettings.tearDownCP();
+
 		}
 		else {
-			PortalSettings.tearDownCP();
+			PortalInstances.tearDownCP();
 
 			JSONUser.tearDownNonAdminUsers();
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/InstanceSettings.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/InstanceSettings.testcase
@@ -17,7 +17,6 @@ definition {
 
 		if (${testPortalInstance} == "true") {
 			PortalSettings.tearDownCP();
-
 		}
 		else {
 			PortalInstances.tearDownCP();


### PR DESCRIPTION
Take a closer look at InstanceSettings.testcase, especially Set Up and Tear Down.

 

We must keep an eye on the tests below:

[LocalFile.InstanceSettings#AssertEmailVerificationIsRequiredByDefault](https://test-1-26.liferay.com/job/test-portal-acceptance-pullrequest-downstream(master)/608378//testReport/com.liferay.poshi.runner/PoshiRunner/test_LocalFile_InstanceSettings_AssertEmailVerificationIsRequiredByDefault_)  [Poshi Report](https://testray.liferay.com/reports/production/logs/2023-05/test-1-32/test-portal-acceptance-pullrequest(master)/9601/functional-tomcat90-mysql57-jdk8/0/0/LocalFile.InstanceSettings_AssertEmailVerificationIsRequiredByDefault/index.html.gz)  [Poshi Summary](https://testray.liferay.com/reports/production/logs/2023-05/test-1-32/test-portal-acceptance-pullrequest(master)/9601/functional-tomcat90-mysql57-jdk8/0/0/LocalFile.InstanceSettings_AssertEmailVerificationIsRequiredByDefault/summary.html.gz) - [Console Output](https://testray.liferay.com/reports/production/logs/2023-05/test-1-32/test-portal-acceptance-pullrequest(master)/9601/functional-tomcat90-mysql57-jdk8/0/0/jenkins-console.txt.gz)
[LocalFile.InstanceSettings#ViewEmailNotificationsSender](https://test-1-39.liferay.com/job/test-portal-acceptance-pullrequest-downstream(master)/385191//testReport/com.liferay.poshi.runner/PoshiRunner/test_LocalFile_InstanceSettings_ViewEmailNotificationsSender_)  [Poshi Report](https://testray.liferay.com/reports/production/logs/2023-05/test-1-32/test-portal-acceptance-pullrequest(master)/9601/functional-tomcat90-mysql57-jdk8/0/1/LocalFile.InstanceSettings_ViewEmailNotificationsSender/index.html.gz)  [Poshi Summary](https://testray.liferay.com/reports/production/logs/2023-05/test-1-32/test-portal-acceptance-pullrequest(master)/9601/functional-tomcat90-mysql57-jdk8/0/1/LocalFile.InstanceSettings_ViewEmailNotificationsSender/summary.html.gz) - [Console Output](https://testray.liferay.com/reports/production/logs/2023-05/test-1-32/test-portal-acceptance-pullrequest(master)/9601/functional-tomcat90-mysql57-jdk8/0/1/jenkins-console.txt.gz)
[LocalFile.InstanceSettings#ViewEnableInSiteSettingWorksWhenDisableInPortalSetting](https://test-1-39.liferay.com/job/test-portal-acceptance-pullrequest-downstream(master)/385191//testReport/com.liferay.poshi.runner/PoshiRunner/test_LocalFile_InstanceSettings_ViewEnableInSiteSettingWorksWhenDisableInPortalSetting_)  [Poshi Report](https://testray.liferay.com/reports/production/logs/2023-05/test-1-32/test-portal-acceptance-pullrequest(master)/9601/functional-tomcat90-mysql57-jdk8/0/1/LocalFile.InstanceSettings_ViewEnableInSiteSettingWorksWhenDisableInPortalSetting/index.html.gz)  [Poshi Summary](https://testray.liferay.com/reports/production/logs/2023-05/test-1-32/test-portal-acceptance-pullrequest(master)/9601/functional-tomcat90-mysql57-jdk8/0/1/LocalFile.InstanceSettings_ViewEnableInSiteSettingWorksWhenDisableInPortalSetting/summary.html.gz) - [Console Output](https://testray.liferay.com/reports/production/logs/2023-05/test-1-32/test-portal-acceptance-pullrequest(master)/9601/functional-tomcat90-mysql57-jdk8/0/1/jenkins-console.txt.gz)
 

[Link to the issue in JIRA](https://issues.liferay.com/browse/LPS-185093)