### PR TITLE
LPS-143585 Adds cadmin css class for portlet configuration

### DIFF
--- a/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
+++ b/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
@@ -253,6 +253,247 @@ html#{$cadmin-selector} {
 			display: none;
 		}
 
+		// CKEditor
+
+		.cke_chrome {
+			border: 1px solid $cadmin-gray-300;
+
+			.cke_bottom {
+				padding: 6px 8px 2px;
+			}
+
+			span.cke_top {
+				padding: 6px 7px;
+			}
+
+			.cke_contents {
+				border: 1px solid #e7e7e7;
+				margin: 0 -1px;
+			}
+
+			&.cke_focus .cke_contents {
+				border-color: $cadmin-primary-l1;
+			}
+
+			.cke_reset_all,
+			.cke_reset_all a,
+			.cke_reset_all textarea {
+				font: 12px sans-serif;
+				text-decoration: none;
+			}
+
+			a.cke_button {
+				border: 2px solid transparent;
+				margin: 0 1px;
+				padding: 6px;
+
+				.cke_button_icon {
+					height: 16px;
+					width: 16px;
+				}
+
+				.cke_button_label {
+					color: $cadmin-gray-600;
+					font-weight: 600;
+					margin-top: 1px;
+					padding-left: 3px;
+				}
+			}
+
+			.cke_combo_on a.cke_combo_button,
+			.cke_combo_off a.cke_combo_button:hover,
+			.cke_combo_off a.cke_combo_button:active,
+			a.cke_button_off:hover,
+			a.cke_button_off:active {
+				background-color: rgba(39, 40, 51, 0.04);
+			}
+
+			a.cke_button_on {
+				background-color: rgba(39, 40, 51, 0.06);
+			}
+
+			a.cke_button__source.cke_button_off
+				+ a.cke_button__expand.cke_button_disabled {
+				display: none;
+			}
+
+			a.cke_combo_button {
+				border: 2px solid transparent;
+				margin: 0 4px;
+				padding: 6px 18px;
+
+				.cke_combo_arrow {
+					border-left: 4px solid transparent;
+					border-right: 4px solid transparent;
+					border-top: 4px solid $cadmin-gray-600;
+				}
+
+				.cke_combo_open {
+					margin: 1px 1px 1px 10px;
+				}
+
+				.cke_combo_text {
+					color: $cadmin-gray-600;
+					font-weight: 600;
+				}
+			}
+
+			.cke_resizer {
+				border-width: 8px 8px 0 0;
+				height: 0;
+				margin: 6px -4px 2px;
+			}
+
+			.cke_toolgroup {
+				margin: 1px 4px 6px 0;
+				padding-right: 3px;
+			}
+
+			.CodeMirror {
+				font-family: monospace;
+
+				.CodeMirror-gutters {
+					background-color: #f7f7f7;
+					border-right: 1px solid #ddd;
+				}
+
+				.CodeMirror-linenumber {
+					color: #999;
+					padding: 0 3px 0 5px;
+					text-align: right;
+				}
+
+				.CodeMirror-cursor {
+					border-left: 1px solid $cadmin-black;
+				}
+
+				.CodeMirror-scroll {
+					height: 100%;
+					margin-bottom: -50px;
+					margin-right: -50px;
+					overflow: scroll;
+					padding-bottom: 50px;
+				}
+
+				pre.CodeMirror-line,
+				pre.CodeMirror-line-like {
+					font-family: inherit;
+					margin: 0;
+				}
+
+				.CodeMirror-scroll,
+				.CodeMirror-sizer,
+				.CodeMirror-gutter,
+				.CodeMirror-gutters,
+				.CodeMirror-linenumber {
+					box-sizing: content-box;
+				}
+
+				.CodeMirror-measure {
+					visibility: hidden;
+				}
+
+				.CodeMirror-selected {
+					background: #d9d9d9;
+				}
+
+				&.CodeMirror-wrap pre.CodeMirror-line,
+				&.CodeMirror-wrap pre.CodeMirror-line-like {
+					white-space: pre-wrap;
+					word-break: normal;
+					word-wrap: break-word;
+				}
+
+				&.CodeMirror-focused .CodeMirror-selected {
+					background: #d7d4f0;
+				}
+
+				&.cm-s-default {
+					.cm-header {
+						color: blue;
+					}
+					.cm-quote {
+						color: #090;
+					}
+					.cm-keyword {
+						color: #708;
+					}
+					.cm-atom {
+						color: #219;
+					}
+					.cm-number {
+						color: #164;
+					}
+					.cm-def {
+						color: #00f;
+					}
+					.cm-variable-3,
+					.cm-type {
+						color: #085;
+					}
+					.cm-comment {
+						color: #a50;
+					}
+					.cm-string {
+						color: #a11;
+					}
+					.cm-string-2 {
+						color: #f50;
+					}
+					.cm-qualifier,
+					.cm-meta {
+						color: #555;
+					}
+					.cm-builtin {
+						color: #30a;
+					}
+					.cm-bracket {
+						color: #997;
+					}
+					.cm-tag {
+						color: #170;
+					}
+					.cm-link,
+					.cm-attribute {
+						color: #00c;
+					}
+					.cm-hr {
+						color: #999;
+					}
+				}
+
+				.cm-negative {
+					color: #d44;
+				}
+
+				.cm-positive {
+					color: #292;
+				}
+
+				.cm-header,
+				.cm-strong {
+					font-weight: bold;
+				}
+
+				.cm-em {
+					font-style: italic;
+				}
+
+				.cm-link {
+					text-decoration: underline;
+				}
+
+				.cm-strikethrough {
+					text-decoration: line-through;
+				}
+
+				.cm-s-default .cm-error,
+				.cm-invalidchar {
+					color: #f00;
+				}
+			}
+		}
+
 		// Taglib Portlet Preview
 
 		.taglib-portlet-preview {

--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/advanced_styling.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/advanced_styling.jsp
@@ -35,9 +35,9 @@
 <aui:input label="enter-your-custom-css" name="customCSS" type="textarea" value="<%= portletConfigurationCSSPortletDisplayContext.getCustomCSS() %>" />
 
 <div id="lfr-add-rule-container">
-	<aui:button cssClass="btn btn-link" id="addId" value="add-a-css-rule-for-this-portlet" />
+	<aui:button cssClass="btn btn-sm" id="addId" value="add-a-css-rule-for-this-portlet" />
 
-	<aui:button cssClass="btn btn-link" id="addClass" value="add-a-css-rule-for-all-portlets-like-this-one" />
+	<aui:button cssClass="btn btn-sm" id="addClass" value="add-a-css-rule-for-all-portlets-like-this-one" />
 </div>
 
 <aui:script>

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/add_configuration_template.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/add_configuration_template.jsp
@@ -25,7 +25,7 @@ String redirect = ParamUtil.getString(request, "redirect");
 	<portlet:param name="portletConfiguration" value="<%= Boolean.TRUE.toString() %>" />
 </portlet:actionURL>
 
-<div class="portlet-configuration-add-template">
+<div class="cadmin portlet-configuration-add-template">
 	<aui:form action="<%= updateArchivedSetupURL %>" cssClass="form" id="fm" method="post" name="fm">
 		<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
 		<aui:input name="portletResource" type="hidden" value="<%= portletResource %>" />

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_configuration.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_configuration.jsp
@@ -22,7 +22,7 @@
 	</liferay-util:include>
 </c:if>
 
-<div class="portlet-configuration-setup">
+<div class="cadmin portlet-configuration-setup">
 
 	<%
 	ConfigurationAction configurationAction = (ConfigurationAction)request.getAttribute(WebKeys.CONFIGURATION_ACTION);

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_configuration_templates.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_configuration_templates.jsp
@@ -20,7 +20,7 @@
 PortletConfigurationTemplatesDisplayContext portletConfigurationTemplatesDisplayContext = new PortletConfigurationTemplatesDisplayContext(request, renderRequest, renderResponse);
 %>
 
-<div class="portlet-configuration-edit-templates">
+<div class="cadmin portlet-configuration-edit-templates">
 	<portlet:actionURL name="deleteArchivedSetups" var="deleteArchivedSetupsURL">
 		<portlet:param name="mvcPath" value="/edit_configuration_templates.jsp" />
 		<portlet:param name="redirect" value="<%= currentURL %>" />

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
@@ -35,7 +35,7 @@ if (Validator.isNotNull(portletConfigurationPermissionsDisplayContext.getModelRe
 }
 %>
 
-<div class="edit-permissions portlet-configuration-edit-permissions">
+<div class="cadmin edit-permissions portlet-configuration-edit-permissions">
 	<div class="portlet-configuration-body-content">
 		<clay:management-toolbar
 			clearResultsURL="<%= portletConfigurationPermissionsDisplayContext.getClearResultsURL() %>"

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_public_render_parameters.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_public_render_parameters.jsp
@@ -32,7 +32,7 @@ Set<PublicRenderParameter> publicRenderParameters = (Set<PublicRenderParameter>)
 	<liferay-util:param name="tabs1" value="communication" />
 </liferay-util:include>
 
-<div class="portlet-configuration-edit-communications">
+<div class="cadmin portlet-configuration-edit-communications">
 	<liferay-frontend:edit-form
 		action="<%= editPublicRenderParametersURL %>"
 		cssClass="form"

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_scope.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_scope.jsp
@@ -64,7 +64,7 @@ for (Layout scopeGroupLayout : LayoutLocalServiceUtil.getScopeGroupLayouts(layou
 	<liferay-util:param name="tabs1" value="scope" />
 </liferay-util:include>
 
-<div class="portlet-configuration-edit-scope">
+<div class="cadmin portlet-configuration-edit-scope">
 	<liferay-frontend:edit-form
 		action="<%= setScopeURL %>"
 		cssClass="form"

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_sharing.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_sharing.jsp
@@ -33,7 +33,7 @@ String widgetURL = PortalUtil.getWidgetURL(portlet, themeDisplay);
 	<liferay-util:param name="tabs1" value="sharing" />
 </liferay-util:include>
 
-<div class="portlet-configuration-edit-sharing">
+<div class="cadmin portlet-configuration-edit-sharing">
 	<liferay-frontend:edit-form
 		action="<%= editSharingURL %>"
 		method="post"

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_supported_clients.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_supported_clients.jsp
@@ -31,7 +31,7 @@ Set<String> allPortletModes = selPortlet.getAllPortletModes();
 	<liferay-util:param name="tabs1" value="supported-clients" />
 </liferay-util:include>
 
-<div class="portlet-configuration-edit-supported-clients">
+<div class="cadmin portlet-configuration-edit-supported-clients">
 	<liferay-frontend:edit-form
 		action="<%= editSupportedClientsURL %>"
 		cssClass="form"

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/tabs1.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/tabs1.jsp
@@ -27,55 +27,57 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "configu
 PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, tabs1), currentURL);
 %>
 
-<clay:navigation-bar
-	navigationItems='<%=
-		new JSPNavigationItemList(pageContext) {
-			{
-				if (selPortlet.getConfigurationActionInstance() != null) {
+<div class="cadmin">
+	<clay:navigation-bar
+		navigationItems='<%=
+			new JSPNavigationItemList(pageContext) {
+				{
+					if (selPortlet.getConfigurationActionInstance() != null) {
+						add(
+							navigationItem -> {
+								navigationItem.setActive(tabs1.equals("setup"));
+								navigationItem.setHref(renderResponse.createRenderURL(), "mvcPath", "/edit_configuration.jsp", "redirect", redirect, "returnToFullPageURL", returnToFullPageURL, "portletConfiguration", Boolean.TRUE.toString(), "portletResource", portletResource);
+								navigationItem.setLabel(LanguageUtil.get(httpServletRequest, "setup"));
+							});
+					}
+
+					if (selPortlet.hasMultipleMimeTypes()) {
+						add(
+							navigationItem -> {
+								navigationItem.setActive(tabs1.equals("supported-clients"));
+								navigationItem.setHref(renderResponse.createRenderURL(), "mvcPath", "/edit_supported_clients.jsp", "redirect", redirect, "returnToFullPageURL", returnToFullPageURL, "portletConfiguration", Boolean.TRUE.toString(), "portletResource", portletResource);
+								navigationItem.setLabel(LanguageUtil.get(httpServletRequest, "supported-clients"));
+							});
+					}
+
+					Set<PublicRenderParameter> publicRenderParameters = selPortlet.getPublicRenderParameters();
+
+					if (!publicRenderParameters.isEmpty()) {
+						add(
+							navigationItem -> {
+								navigationItem.setActive(tabs1.equals("communication"));
+								navigationItem.setHref(renderResponse.createRenderURL(), "mvcPath", "/edit_public_render_parameters.jsp", "redirect", redirect, "returnToFullPageURL", returnToFullPageURL, "portletConfiguration", Boolean.TRUE.toString(), "portletResource", portletResource);
+								navigationItem.setLabel(LanguageUtil.get(httpServletRequest, "communication"));
+							});
+					}
+
 					add(
 						navigationItem -> {
-							navigationItem.setActive(tabs1.equals("setup"));
-							navigationItem.setHref(renderResponse.createRenderURL(), "mvcPath", "/edit_configuration.jsp", "redirect", redirect, "returnToFullPageURL", returnToFullPageURL, "portletConfiguration", Boolean.TRUE.toString(), "portletResource", portletResource);
-							navigationItem.setLabel(LanguageUtil.get(httpServletRequest, "setup"));
+							navigationItem.setActive(tabs1.equals("sharing"));
+							navigationItem.setHref(renderResponse.createRenderURL(), "mvcPath", "/edit_sharing.jsp", "redirect", redirect, "returnToFullPageURL", returnToFullPageURL, "portletConfiguration", Boolean.TRUE.toString(), "portletResource", portletResource);
+							navigationItem.setLabel(LanguageUtil.get(httpServletRequest, "sharing"));
 						});
-				}
 
-				if (selPortlet.hasMultipleMimeTypes()) {
-					add(
-						navigationItem -> {
-							navigationItem.setActive(tabs1.equals("supported-clients"));
-							navigationItem.setHref(renderResponse.createRenderURL(), "mvcPath", "/edit_supported_clients.jsp", "redirect", redirect, "returnToFullPageURL", returnToFullPageURL, "portletConfiguration", Boolean.TRUE.toString(), "portletResource", portletResource);
-							navigationItem.setLabel(LanguageUtil.get(httpServletRequest, "supported-clients"));
-						});
-				}
-
-				Set<PublicRenderParameter> publicRenderParameters = selPortlet.getPublicRenderParameters();
-
-				if (!publicRenderParameters.isEmpty()) {
-					add(
-						navigationItem -> {
-							navigationItem.setActive(tabs1.equals("communication"));
-							navigationItem.setHref(renderResponse.createRenderURL(), "mvcPath", "/edit_public_render_parameters.jsp", "redirect", redirect, "returnToFullPageURL", returnToFullPageURL, "portletConfiguration", Boolean.TRUE.toString(), "portletResource", portletResource);
-							navigationItem.setLabel(LanguageUtil.get(httpServletRequest, "communication"));
-						});
-				}
-
-				add(
-					navigationItem -> {
-						navigationItem.setActive(tabs1.equals("sharing"));
-						navigationItem.setHref(renderResponse.createRenderURL(), "mvcPath", "/edit_sharing.jsp", "redirect", redirect, "returnToFullPageURL", returnToFullPageURL, "portletConfiguration", Boolean.TRUE.toString(), "portletResource", portletResource);
-						navigationItem.setLabel(LanguageUtil.get(httpServletRequest, "sharing"));
-					});
-
-				if (selPortlet.isScopeable()) {
-					add(
-						navigationItem -> {
-							navigationItem.setActive(tabs1.equals("scope"));
-							navigationItem.setHref(renderResponse.createRenderURL(), "mvcPath", "/edit_scope.jsp", "redirect", redirect, "returnToFullPageURL", returnToFullPageURL, "portletConfiguration", Boolean.TRUE.toString(), "portletResource", portletResource);
-							navigationItem.setLabel(LanguageUtil.get(httpServletRequest, "scope"));
-						});
+					if (selPortlet.isScopeable()) {
+						add(
+							navigationItem -> {
+								navigationItem.setActive(tabs1.equals("scope"));
+								navigationItem.setHref(renderResponse.createRenderURL(), "mvcPath", "/edit_scope.jsp", "redirect", redirect, "returnToFullPageURL", returnToFullPageURL, "portletConfiguration", Boolean.TRUE.toString(), "portletResource", portletResource);
+								navigationItem.setLabel(LanguageUtil.get(httpServletRequest, "scope"));
+							});
+					}
 				}
 			}
-		}
-	%>'
-/>
+		%>'
+	/>
+</div>


### PR DESCRIPTION
Hi guys!!

In Echo team we are working on adding `cadmin` to the portlet configuration. However, when adding `cadmin`, all CKEditor styles were broken. In this PR, I have added the minimal css so that CKEditor looks correctly by adding `cadmin`. @pat270 @marcoscv-work could you take a look? Only the last two commits (https://github.com/liferay-peds/liferay-portal/pull/70/commits/42dd37d6e5a055f29a85fe24af142d5f9ee679f7, https://github.com/liferay-peds/liferay-portal/pull/70/commits/cfa8ef1006100f440e8626a94ffa7c3ffbb40660) needs to be reviewed, since the rest have been reviewed from Echo.

Here I share some screenshots of:

- Before adding `cadmin`
 <img width="500" alt="ckeditor_before" src="https://github.com/liferay-peds/liferay-portal/assets/9701095/ace963cb-54aa-4ac3-96dc-124d29fd905a">

- After applying `cadmin`
<img width="500" alt="cadmin_and_ckeditor_before" src="https://github.com/liferay-peds/liferay-portal/assets/9701095/c20b86bf-35eb-477c-b951-f36899b64c1e">

- With the changes applied in this PR
<img width="500" alt="cadmin_and_ckeditor_after" src="https://github.com/liferay-peds/liferay-portal/assets/9701095/dca171ea-995c-451f-9ebf-34c1284c31b9">


Thanks in advance!