### PR TITLE
LPS-186425 - Test Fix for LanguageOverrideExportImport#CanViewFileUploadFieldIsRequired

### DIFF
--- a/modules/apps/portal-language/portal-language-override-test/src/testFunctional/tests/LanguageOverrideExportImport.testcase
+++ b/modules/apps/portal-language/portal-language-override-test/src/testFunctional/tests/LanguageOverrideExportImport.testcase
@@ -284,7 +284,7 @@ this-is-a-language-key=This is a language key''',
 		}
 
 		task ("Then assert error message and File Upload field is required") {
-			FormPortlet.viewValidationErrorMessage(validationErrorMessage = "The File field is required.");
+			FormPortlet.viewValidationErrorMessage(validationErrorMessage = "The File Upload field is required.");
 
 			FormFields.viewFieldRequired(fieldLabel = "File Upload");
 		}


### PR DESCRIPTION
This PR aims to fix **LanguageOverrideExportImport#CanViewFileUploadFieldIsRequired** test by simply updating the text attributed to the variable.

[Poshi  Report](https://drive.google.com/file/d/1btpL4KclkL30i29wjh2m_j3Vf2wizUzj/view?usp=sharing)

[Jira Ticket](https://issues.liferay.com/browse/LPS-186425)

