### PR TITLE
LPS-167460 HR_43 Add Calendar page content can't be clearly visible when zooming in on the page to 100%

### DIFF
--- a/portal-web/docroot/html/taglib/ui/input_permissions/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_permissions/page.jsp
@@ -119,7 +119,7 @@ String modelName = (String)request.getAttribute("liferay-ui:input-permissions:mo
 					<option <%= inputPermissionsViewRole.equals(RoleConstants.OWNER) ? "selected=\"selected\"" : "" %> value="<%= RoleConstants.OWNER %>"><liferay-ui:message key="owner" /></option>
 				</select>
 
-				<button aria-controls="<%= uniqueNamespace %>inputPermissionsTable" aria-expanded="<%= inputPermissionsShowOptions %>" class="btn btn-secondary btn-sm mt-3" id="<%= uniqueNamespace %>inputPermissionsOptionsButton" onclick="<%= uniqueNamespace %>inputPermissionsToggle();" type="button">
+				<button aria-controls="<%= uniqueNamespace %>inputPermissionsTable" aria-expanded="<%= inputPermissionsShowOptions %>" class="btn btn-secondary btn-sm <%= inputPermissionsShowOptions ? "mb-1 mt-3" : "mb-5 mt-3"%>" id="<%= uniqueNamespace %>inputPermissionsOptionsButton" onclick="<%= uniqueNamespace %>inputPermissionsToggle();" type="button">
 					<%= inputPermissionsShowOptions ? LanguageUtil.get(request, "hide-options") : LanguageUtil.get(request, "more-options") %>
 				</button>
 
@@ -180,6 +180,7 @@ String modelName = (String)request.getAttribute("liferay-ui:input-permissions:mo
 				if (inputPermissionsOptionsButton) {
 					inputPermissionsOptionsButton.innerText = force ? '<%= LanguageUtil.get(request, "hide-options") %>' :'<%= LanguageUtil.get(request, "more-options") %>' ;
 					inputPermissionsOptionsButton.ariaExpanded = force;
+					inputPermissionsOptionsButton.classList = force ? "btn btn-secondary btn-sm mb-1 mt-3" : "btn btn-secondary btn-sm mb-5 mt-3";
 				}
 			}
 


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-167460

From what I gathered from the discussion in the ticket, the only problem left was that the button was disappearing and it needed some bottom margin to make it visible at all times. 

Issue 2 seems to be resolved as the element is now a `<button>` and not `<a>` as it was before (using a role button).

I added a condition in  _class_ to make the margin different depending on `inputPermissionsShowOptions` because when the _hide options_ button was on, the margin-bottom created a big gap between the button and the table.

I also had to adjust the function that updated the values in _class_ once I clicked the button more than once because it was not updating the value in `inputPermissionsShowOptions` and it was resetting the value inside _class_.