### PR TITLE
LPS-187153 Test fix for ClayMultiselect#CanSelectFromAutoComplete

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayMultiselect.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayMultiselect.testcase
@@ -78,8 +78,8 @@ definition {
 			value1 = "three");
 
 		AssertElementPresent(
-			tagName = "three",
-			locator1 = "CommerceWidget#TAG_FACET_COMPACT_LAYOUT");
+			locator1 = "CommerceWidget#TAG_FACET_COMPACT_LAYOUT",
+			tagName = "three");
 
 		DoubleClick(
 			key_item = "three",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayMultiselect.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayMultiselect.testcase
@@ -53,7 +53,7 @@ definition {
 			locator1 = "ClaySamplePortlet#MULTISELECT_INPUT",
 			value1 = "three");
 
-		Click(
+		DoubleClick(
 			key_item = "three",
 			locator1 = "ClaySamplePortlet#MULTISELECT_DROPDOWN_ITEM");
 
@@ -78,10 +78,10 @@ definition {
 			value1 = "three");
 
 		AssertElementPresent(
-			key_item = "three",
-			locator1 = "ClaySamplePortlet#MULTISELECT_DROPDOWN_ITEM_STICKER");
+			tagName = "three",
+			locator1 = "CommerceWidget#TAG_FACET_COMPACT_LAYOUT");
 
-		Click(
+		DoubleClick(
 			key_item = "three",
 			locator1 = "ClaySamplePortlet#MULTISELECT_DROPDOWN_ITEM");
 


### PR DESCRIPTION
This pull request aims to fix ClayMultiselect#CanSelectFromAutoComplete test since it failed on our last run of `ci:test:peds`.

I changed `Click` to `DoubleClick` and modified a path.

[Jira Ticket](https://issues.liferay.com/browse/LPS-187153)

[Poshi Report](https://drive.google.com/file/d/1n_yyuKgVbICyMnrCWKKDxbaKjupMLRPX/view?usp=sharing) after the modifications I did.

