### PR TITLE
LPS-189279 fixes error of the TreeView example without the checkbox with indeterminate state

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleTreeViewWithCheckbox.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleTreeViewWithCheckbox.js
@@ -55,7 +55,7 @@ export default function ClaySampleTreeViewWithCheckbox() {
 			showExpanderOnHover={false}
 		>
 			{(item) => (
-				<TreeView.Item key={item.name}>
+				<TreeView.Item>
 					<TreeView.ItemStack>
 						<Checkbox />
 


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPS-189279

The problem is that we made an internal change to use the value typed in the `key` property to have greater order of importance than the `id` key in the `items` data. This was breaking this example, so I just changed it. We don't consider this a regression because the behavior before was a bug.