### PR TITLE
LPS-187706 Enable a visibilityControllerKey attribute for configuration interface methods

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-api/src/main/java/com/liferay/configuration/admin/display/ConfigurationVisibilityController.java
+++ b/modules/apps/configuration-admin/configuration-admin-api/src/main/java/com/liferay/configuration/admin/display/ConfigurationVisibilityController.java
@@ -24,7 +24,9 @@ import java.io.Serializable;
 public interface ConfigurationVisibilityController {
 
 	public default String getKey() {
-		return null;
+		Class<? extends ConfigurationVisibilityController> clazz = getClass();
+
+		return clazz.getName();
 	}
 
 	public boolean isVisible(

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/model/ConfigurationModel.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/model/ConfigurationModel.java
@@ -14,6 +14,7 @@
 
 package com.liferay.configuration.admin.web.internal.model;
 
+import com.liferay.configuration.admin.web.internal.display.context.ConfigurationScopeDisplayContext;
 import com.liferay.petra.lang.HashUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition.Scope;
@@ -54,6 +55,7 @@ public class ConfigurationModel implements ExtendedObjectClassDefinition {
 			configurationModel.getBundleLocation(),
 			configurationModel.getBundleSymbolicName(),
 			configurationModel.getClassLoader(), configuration,
+			configurationModel.getConfigurationScopeDisplayContext(),
 			configurationModel.getExtendedObjectClassDefinition(),
 			configurationModel.isFactory());
 	}
@@ -61,6 +63,7 @@ public class ConfigurationModel implements ExtendedObjectClassDefinition {
 	public ConfigurationModel(
 		String bundleLocation, String bundleSymbolicName,
 		ClassLoader classLoader, Configuration configuration,
+		ConfigurationScopeDisplayContext configurationScopeDisplayContext,
 		ExtendedObjectClassDefinition extendedObjectClassDefinition,
 		boolean factory) {
 
@@ -68,6 +71,7 @@ public class ConfigurationModel implements ExtendedObjectClassDefinition {
 		_bundleSymbolicName = bundleSymbolicName;
 		_classLoader = classLoader;
 		_configuration = configuration;
+		_configurationScopeDisplayContext = configurationScopeDisplayContext;
 		_extendedObjectClassDefinition = extendedObjectClassDefinition;
 		_factory = factory;
 
@@ -93,7 +97,7 @@ public class ConfigurationModel implements ExtendedObjectClassDefinition {
 
 		this(
 			bundleLocation, bundleSymbolicName,
-			ConfigurationModel.class.getClassLoader(), configuration,
+			ConfigurationModel.class.getClassLoader(), configuration, null,
 			extendedObjectClassDefinition, factory);
 	}
 
@@ -132,6 +136,12 @@ public class ConfigurationModel implements ExtendedObjectClassDefinition {
 
 	public Configuration getConfiguration() {
 		return _configuration;
+	}
+
+	public ConfigurationScopeDisplayContext
+		getConfigurationScopeDisplayContext() {
+
+		return _configurationScopeDisplayContext;
 	}
 
 	@Override
@@ -407,6 +417,8 @@ public class ConfigurationModel implements ExtendedObjectClassDefinition {
 	private final ClassLoader _classLoader;
 	private final Configuration _configuration;
 	private Map<String, Object> _configurationOverrideProperties;
+	private final ConfigurationScopeDisplayContext
+		_configurationScopeDisplayContext;
 	private final ExtendedObjectClassDefinition _extendedObjectClassDefinition;
 	private final Map<String, String> _extensionAttributes;
 	private final boolean _factory;

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationModelRetrieverImpl.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationModelRetrieverImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.configuration.admin.web.internal.util;
 
+import com.liferay.configuration.admin.web.internal.display.context.ConfigurationScopeDisplayContext;
 import com.liferay.configuration.admin.web.internal.model.ConfigurationModel;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
@@ -222,12 +223,16 @@ public class ConfigurationModelRetrieverImpl
 
 		List<ConfigurationModel> factoryInstances = new ArrayList<>();
 
+		ConfigurationScopeDisplayContext configurationScopeDisplayContext =
+			new ConfigurationScopeDisplayContext(scope, scopePK);
+
 		for (Configuration configuration : configurations) {
 			ConfigurationModel curConfigurationModel = new ConfigurationModel(
 				configuration.getBundleLocation(),
 				factoryConfigurationModel.getBundleSymbolicName(),
 				factoryConfigurationModel.getClassLoader(), configuration,
-				factoryConfigurationModel, false);
+				configurationScopeDisplayContext, factoryConfigurationModel,
+				false);
 
 			factoryInstances.add(curConfigurationModel);
 		}
@@ -289,10 +294,14 @@ public class ConfigurationModelRetrieverImpl
 
 		BundleWiring bundleWiring = bundle.adapt(BundleWiring.class);
 
+		ConfigurationScopeDisplayContext configurationScopeDisplayContext =
+			new ConfigurationScopeDisplayContext(scope, scopePK);
+
 		ConfigurationModel configurationModel = new ConfigurationModel(
 			StringPool.QUESTION, bundle.getSymbolicName(),
 			bundleWiring.getClassLoader(),
 			getConfiguration(pid, scope, scopePK),
+			configurationScopeDisplayContext,
 			extendedMetaTypeInformation.getObjectClassDefinition(pid, locale),
 			factory);
 

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationModelToDDMFormConverter.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationModelToDDMFormConverter.java
@@ -15,6 +15,7 @@
 package com.liferay.configuration.admin.web.internal.util;
 
 import com.liferay.configuration.admin.definition.ConfigurationFieldOptionsProvider;
+import com.liferay.configuration.admin.web.internal.display.context.ConfigurationScopeDisplayContext;
 import com.liferay.configuration.admin.web.internal.model.ConfigurationModel;
 import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
@@ -550,6 +551,23 @@ public class ConfigurationModelToDDMFormConverter {
 		if (ArrayUtil.contains(hiddenFieldKeys, attributeDefinition.getID()) ||
 			ArrayUtil.contains(
 				hiddenFieldKeys, attributeDefinition.getName())) {
+
+			ddmFormField.setVisibilityExpression("FALSE");
+
+			return;
+		}
+
+		ConfigurationScopeDisplayContext configurationScopeDisplayContext =
+			_configurationModel.getConfigurationScopeDisplayContext();
+
+		Map<String, String> extensionAttributes = _getExtensionAttributes(
+			attributeDefinition);
+
+		if ((configurationScopeDisplayContext != null) &&
+			!ConfigurationVisibilityUtil.isVisibleByKey(
+				extensionAttributes.get("visibility-controller-key"),
+				configurationScopeDisplayContext.getScope(),
+				configurationScopeDisplayContext.getScopePK())) {
 
 			ddmFormField.setVisibilityExpression("FALSE");
 		}

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationVisibilityUtil.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationVisibilityUtil.java
@@ -189,11 +189,6 @@ public class ConfigurationVisibilityUtil {
 				ConfigurationVisibilityController service =
 					bundleContext.getService(serviceReference);
 
-				Class<? extends ConfigurationVisibilityController> clazz =
-					service.getClass();
-
-				emitter.emit(clazz.getName());
-
 				String key = service.getKey();
 
 				if (!Validator.isBlank(key)) {

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationVisibilityUtil.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationVisibilityUtil.java
@@ -79,6 +79,24 @@ public class ConfigurationVisibilityUtil {
 		return true;
 	}
 
+	public static boolean isVisibleByKey(
+		String visibilityControllerKey,
+		ExtendedObjectClassDefinition.Scope scope, Serializable scopePK) {
+
+		if (Validator.isNull(visibilityControllerKey)) {
+			return true;
+		}
+
+		ConfigurationVisibilityController configurationVisibilityController =
+			_serviceTrackerMap.getService(visibilityControllerKey);
+
+		if (configurationVisibilityController == null) {
+			return true;
+		}
+
+		return configurationVisibilityController.isVisible(scope, scopePK);
+	}
+
 	private static Class<?> _getClass(Bundle bundle, String pid) {
 		try {
 			return bundle.loadClass(pid);

--- a/modules/apps/portal-configuration/portal-configuration-metatype-definitions-annotations/src/main/java/com/liferay/portal/configuration/metatype/definitions/annotations/internal/AnnotationsExtendedAttributeDefinition.java
+++ b/modules/apps/portal-configuration/portal-configuration-metatype-definitions-annotations/src/main/java/com/liferay/portal/configuration/metatype/definitions/annotations/internal/AnnotationsExtendedAttributeDefinition.java
@@ -164,6 +164,9 @@ public class AnnotationsExtendedAttributeDefinition
 						"required-input",
 						String.valueOf(
 							extendedAttributeDefinition.requiredInput())
+					).put(
+						"visibility-controller-key",
+						extendedAttributeDefinition.visibilityControllerKey()
 					).build());
 			}
 		}

--- a/modules/apps/static/portal-configuration/portal-configuration-metatype-api/src/main/java/com/liferay/portal/configuration/metatype/annotations/ExtendedAttributeDefinition.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-metatype-api/src/main/java/com/liferay/portal/configuration/metatype/annotations/ExtendedAttributeDefinition.java
@@ -43,4 +43,6 @@ public @interface ExtendedAttributeDefinition {
 
 	public boolean requiredInput() default false;
 
+	public String visibilityControllerKey() default "";
+
 }


### PR DESCRIPTION
This is an update for [LPS-187706](https://issues.liferay.com/browse/LPS-187706).

Hey @ethib137, this change is only for the updates to `configuration-admin-web` that deals with allowing the `visibilityControllerKey` on individual method attributes. It does not include the update to `feature-flag-web` that needs to be audited by the performance team, those will be sent separately under [LPS-171225](https://liferay.atlassian.net/browse/LPS-171225).