### PR TITLE
LPS-188743 - Site Settings Accessibility Menu sometimes traps keyboard and mouse actions after opening the modal

### DIFF
--- a/modules/apps/accessibility/accessibility-menu-web/src/main/resources/META-INF/resources/js/AccessibilityMenu.tsx
+++ b/modules/apps/accessibility/accessibility-menu-web/src/main/resources/META-INF/resources/js/AccessibilityMenu.tsx
@@ -55,6 +55,7 @@ type Props = {
 	settings: Array<Setting>;
 };
 
+const BEFORE_NAVIGATE_EVENT_NAME = 'beforeNavigate';
 const OPEN_ACCESSIBILITY_MENU_EVENT_NAME = 'openAccessibilityMenu';
 
 const AccessibilityMenu = (props: Props) => {
@@ -101,10 +102,24 @@ const AccessibilityMenu = (props: Props) => {
 
 		Liferay.on(OPEN_ACCESSIBILITY_MENU_EVENT_NAME, openAccessibilityMenu);
 
-		return () => {
+		const detachOpenAccessibilityMenuEvent = () => {
 			Liferay.detach(
 				OPEN_ACCESSIBILITY_MENU_EVENT_NAME,
 				openAccessibilityMenu
+			);
+		};
+
+		Liferay.once(
+			BEFORE_NAVIGATE_EVENT_NAME,
+			detachOpenAccessibilityMenuEvent
+		);
+
+		return () => {
+			detachOpenAccessibilityMenuEvent();
+
+			Liferay.detach(
+				BEFORE_NAVIGATE_EVENT_NAME,
+				detachOpenAccessibilityMenuEvent
 			);
 		};
 	}, [onOpenChange]);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-188743

Due to Senna, we need to detach the openAccessibilityMenu event before SPA navigation to avoid opening the menu multiple times.