### PR TITLE
LPS-190150 add reduced motion to the product menu

### DIFF
--- a/modules/apps/frontend-js/frontend-js-collapse-support-web/src/main/resources/META-INF/resources/CollapseProvider.ts
+++ b/modules/apps/frontend-js/frontend-js-collapse-support-web/src/main/resources/META-INF/resources/CollapseProvider.ts
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {delegate} from 'frontend-js-web';
+import {delegate, isReducedMotion} from 'frontend-js-web';
 
 const CssClass = {
 	COLLAPSE: 'collapse',
@@ -107,7 +107,7 @@ class CollapseProvider {
 			Liferay.fire(this.EVENT_HIDDEN, {panel, trigger});
 		};
 
-		if (this._prefersReducedMotion()) {
+		if (isReducedMotion()) {
 			onHidden();
 		}
 		else {
@@ -179,7 +179,7 @@ class CollapseProvider {
 			Liferay.fire(this.EVENT_SHOWN, {panel, trigger});
 		};
 
-		if (this._prefersReducedMotion()) {
+		if (isReducedMotion()) {
 			onShown();
 		}
 		else {
@@ -229,10 +229,6 @@ class CollapseProvider {
 			}
 		}
 	};
-
-	_prefersReducedMotion() {
-		return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-	}
 
 	_setTransitionEndEvent() {
 		const sampleElement = document.body;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
@@ -892,3 +892,5 @@ export function setSessionValue(
 	value: Record<string, any> | string | boolean,
 	options?: {useHttpSession: boolean}
 ): Promise<any>;
+
+export function isReducedMotion(): boolean;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -147,6 +147,7 @@ export {default as toggleControls} from './liferay/util/toggle_controls';
 export {default as toggleDisabled} from './liferay/util/toggle_disabled';
 export {default as toggleRadio} from './liferay/util/toggle_radio';
 export {default as toggleSelectBox} from './liferay/util/toggle_select_box';
+export {isReducedMotion} from './liferay/util/reducedMotion';
 export {
 	getCheckedCheckboxes,
 	getUncheckedCheckboxes,

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/side_navigation.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/side_navigation.es.js
@@ -331,6 +331,8 @@ SideNavigation.prototype = {
 	_bindUI() {
 		this._subscribeClickTrigger();
 
+		this._subscribeReducedMotion();
+
 		this._subscribeClickSidenavClose();
 	},
 
@@ -548,7 +550,9 @@ SideNavigation.prototype = {
 						}
 					}
 
-					addClass(container, 'sidenav-transition');
+					if (!this.isReducedMotion()) {
+						addClass(container, 'sidenav-transition');
+					}
 
 					setStyles(content, {
 						'padding-right': px(paddingRight),
@@ -625,7 +629,9 @@ SideNavigation.prototype = {
 							? options.width + options.gutter - contentMargin
 							: options.width + options.gutter;
 
-					addClass(container, 'sidenav-transition');
+					if (!this.isReducedMotion()) {
+						addClass(container, 'sidenav-transition');
+					}
 
 					setStyles(content, {
 						'padding-right': px(paddingRight),
@@ -808,12 +814,27 @@ SideNavigation.prototype = {
 		}
 	},
 
+	_subscribeReducedMotion() {
+		const instance = this;
+
+		Liferay.Loader.require('frontend-js-web/index', ({isReducedMotion}) => {
+			instance.isReducedMotion = isReducedMotion;
+		});
+	},
+
 	_subscribeSidenavTransitionEnd(element, fn) {
-		setTimeout(() => {
+		if (this.isReducedMotion()) {
 			removeClass(element, 'sidenav-transition');
 
 			fn();
-		}, SideNavigation.TRANSITION_DURATION);
+		}
+		else {
+			setTimeout(() => {
+				removeClass(element, 'sidenav-transition');
+
+				fn();
+			}, SideNavigation.TRANSITION_DURATION);
+		}
 	},
 
 	clearHeight() {
@@ -978,16 +999,20 @@ SideNavigation.prototype = {
 				instance._focusTrigger();
 			});
 
+			const isReducedMotion = instance.isReducedMotion();
+
 			if (hasClass(content, openClass)) {
 				setClasses(content, {
 					[closedClass]: true,
 					[openClass]: false,
-					'sidenav-transition': true,
+					'sidenav-transition': !isReducedMotion,
 				});
 			}
 
-			addClass(container, 'sidenav-transition');
-			addClass(toggler, 'sidenav-transition');
+			if (!isReducedMotion) {
+				addClass(container, 'sidenav-transition');
+				addClass(toggler, 'sidenav-transition');
+			}
 
 			setClasses(container, {
 				[closedClass]: true,
@@ -1269,20 +1294,22 @@ SideNavigation.prototype = {
 				this._focusNavigation();
 			});
 
+			const isReducedMotion = instance.isReducedMotion();
+
 			setClasses(content, {
 				[closedClass]: false,
 				[openClass]: true,
-				'sidenav-transition': true,
+				'sidenav-transition': !isReducedMotion,
 			});
 			setClasses(container, {
 				[closedClass]: false,
 				[openClass]: true,
-				'sidenav-transition': true,
+				'sidenav-transition': !isReducedMotion,
 			});
 			setClasses(toggler, {
 				'active': true,
 				[openClass]: true,
-				'sidenav-transition': true,
+				'sidenav-transition': !isReducedMotion,
 			});
 		}
 	},
@@ -1392,8 +1419,10 @@ SideNavigation.prototype = {
 			}
 		}
 
-		addClass(container, 'sidenav-transition');
-		addClass(toggler, 'sidenav-transition');
+		if (!instance.isReducedMotion()) {
+			addClass(container, 'sidenav-transition');
+			addClass(toggler, 'sidenav-transition');
+		}
 
 		if (closed) {
 			instance.showSidenav();

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/reducedMotion.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/reducedMotion.js
@@ -12,20 +12,22 @@
  * details.
  */
 
-declare class CollapseProvider {
-	_transitioning?: boolean;
-	_transitionEndEvent?: any;
-	EVENT_HIDDEN: string;
-	EVENT_HIDE: string;
-	EVENT_SHOW: string;
-	EVENT_SHOWN: string;
-	constructor();
-	hide: ({panel, trigger}: {panel?: any; trigger?: any}) => void;
-	show: ({panel, trigger}: {panel?: any; trigger?: any}) => void;
-	_getDimension(panel: any): string;
-	_getPanel(trigger: any): any;
-	_getTrigger(panel: any): Element | null;
-	_onTriggerClick: (event: any) => void;
-	_setTransitionEndEvent(): void;
+import {
+	CONSTANTS,
+	accessibilityMenuAtom,
+} from '@liferay/accessibility-settings-state-web';
+import {State} from '@liferay/frontend-js-state-web';
+
+function isReducedMotion() {
+	const accessibilityMenu = State.read(accessibilityMenuAtom);
+	const reducedMotion =
+		accessibilityMenu[CONSTANTS.ACCESSIBILITY_SETTING_REDUCED_MOTION];
+
+	if (reducedMotion?.value) {
+		return true;
+	}
+
+	return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
-export default CollapseProvider;
+
+export {isReducedMotion};


### PR DESCRIPTION
Jira ticket: [LPS-190150](https://liferay.atlassian.net/browse/LPS-190150)

Basically I added a util so that it can be used in non-React.js components with support to read the status of the accessibility menu and as a fallback it uses the user's system configuration.

So implementations like the `frontend-js-collapse-support-web` module can use the `isReducedMotion()` function to check whether to animate or not.