### PR TITLE
LPS-187582 - Add Autom. Test ChangedConfigurationSettingByAuthenticatedUserWillBeSavedInDatabase.

### DIFF
--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/macros/AccessibilityMenu.macro
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/macros/AccessibilityMenu.macro
@@ -26,7 +26,7 @@ definition {
 		}
 	}
 
-	macro goToAccessibilityMenu {
+	macro goToAccessibilityMenuQuickLink {
 		KeyPress(
 			locator1 = "//body",
 			value1 = "\TAB");
@@ -35,6 +35,22 @@ definition {
 			key_link = "Skip to Main Content",
 			locator1 = "AccessibilityMenu#QUICK_LINK",
 			value1 = "\TAB");
+	}
+
+	macro openAccessibilityMenu {
+		KeyPress(
+			locator1 = "//body",
+			value1 = "\TAB");
+
+		KeyPress(
+			key_link = "Skip to Main Content",
+			locator1 = "AccessibilityMenu#QUICK_LINK",
+			value1 = "\TAB");
+
+		KeyPress(
+			key_link = "Accessibility Menu",
+			locator1 = "AccessibilityMenu#QUICK_LINK",
+			value1 = "\ENTER");
 	}
 
 }

--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
@@ -97,7 +97,7 @@ definition {
 			AccessibilityMenu.openAccessibilityMenu();
 
 			Uncheck.uncheckNotVisible(
-				key_toggleSwitchLabel = "Expanded Text",
+				key_toggleSwitchLabel = "Underlined Links",
 				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
 		}
 

--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
@@ -10,6 +10,8 @@ definition {
 	setUp {
 		TestCase.setUpPortalInstance();
 
+		TestUtils.hardRefresh();
+
 		User.firstLoginPG();
 
 		task ("Given Accessibility Menu enabled at Instance Settings level") {
@@ -61,12 +63,12 @@ definition {
 	}
 
 	@description = "LPS-178192. Verifies the modified accessibility configuration state is persisted in database for signed in user."
-	@ignore = "Test Stub"
 	@priority = 5
 	test ChangedConfigurationSettingByAuthenticatedUserWillBeSavedInDatabase {
 		property portal.acceptance = "true";
 
 		task ("Given created new user A") {
+			
 			JSONUser.addUser(
 				userEmailAddress = "userea@liferay.com",
 				userFirstName = "userfnA",
@@ -80,27 +82,11 @@ definition {
 				userLoginFullName = "userfnA userlnA");
 		}
 
-		task ("And toggle an accessibility configuration (underline to OFF state)") {
+		task ("And toggle an accessibility configuration (set underline to ON state)") {
 
-			// Since it is off by default, I guess you meant to "ON" state, right?
+			AccessibilityMenu.openAccessibilityMenu();
 
-			AccessibilityMenu.goToAccessibilityMenu();
-
-			KeyPress(
-				key_link = "Accessibility Menu",
-				locator1 = "AccessibilityMenu#QUICK_LINK",
-				value1 = "\ENTER");
-
-			KeyPress(
-				locator1 = "//body",
-				value1 = "\TAB");
-
-			KeyPress(
-				key_modalTitle = "Accessibility Help Menu",
-				locator1 = "Button#CLOSE_MODAL",
-				value1 = "\TAB");
-
-			Check.checkToggleSwitch(
+			Check.checkNotVisible(
 				key_toggleSwitchLabel = "Underlined Links",
 				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
 		}
@@ -109,34 +95,11 @@ definition {
 			SignOut.signOut();
 		}
 
-		task ("And guest user sets shows underline configuration to OFF") {
-			User._login();
+		task ("And guest user sets shows Expanded Text configuration to ON") {
+			AccessibilityMenu.openAccessibilityMenu();
 
-			AccessibilityMenu.goToAccessibilityMenu();
-
-			KeyPress(
-				key_link = "Accessibility Menu",
-				locator1 = "AccessibilityMenu#QUICK_LINK",
-				value1 = "\ENTER");
-
-			KeyPress(
-				locator1 = "//body",
-				value1 = "\TAB");
-
-			KeyPress(
-				key_modalTitle = "Accessibility Help Menu",
-				locator1 = "Button#CLOSE_MODAL",
-				value1 = "\TAB");
-
-			//Check.checkToggleSwitch(
-			//	key_toggleSwitchLabel = "Underlined Links",
-			//	locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
-
-		}
-
-		task ("And guest user sets shows underline configuration to ON") {
-			Uncheck.uncheckToggleSwitch(
-				key_toggleSwitchLabel = "Underlined Links",
+			Uncheck.uncheckNotVisible(
+				key_toggleSwitchLabel = "Expanded Text",
 				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
 		}
 
@@ -147,12 +110,8 @@ definition {
 		}
 
 		task ("When open Accessibility Menu") {
-			AccessibilityMenu.goToAccessibilityMenu();
+			AccessibilityMenu.openAccessibilityMenu();
 
-			KeyPress(
-				key_link = "Accessibility Menu",
-				locator1 = "AccessibilityMenu#QUICK_LINK",
-				value1 = "\ENTER");
 		}
 
 		task ("Then accessibility configuration states persisted in database for user A") {
@@ -160,43 +119,7 @@ definition {
 				key_toggleSwitchLabel = "Underlined Links",
 				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
 
-			// Underline is set to OFF
-
 		}
-
-		// ---------------------------------- before
-
-		//task ("When Accessibility Menu is focused with keyboard") {
-		//	AccessibilityMenu.goToAccessibilityMenu();
-		//}
-		//task ("And toggle show underline to OFF state") {
-		//	KeyPress(
-		//		key_link = "Accessibility Menu",
-		//		locator1 = "AccessibilityMenu#QUICK_LINK",
-		//		value1 = "\ENTER");
-		//}
-		//task ("And can navigate to a switch toggle with keyboard") {
-		//	KeyPress(
-		//		locator1 = "//body",
-		//		value1 = "\TAB");
-		//	KeyPress(
-		//		key_modalTitle = "Accessibility Help Menu",
-		//		locator1 = "Button#CLOSE_MODAL",
-		//		value1 = "\TAB");
-		//}
-		//task ("And sign out") {
-		//	signOut();
-		//}
-		//task ("And guest user sets shows underline configuration to OFF") {
-		//}
-		//task ("And guest user sets shows underline configuration to ON") {
-		//}
-		//task ("And when sign in as user A") {
-		//}
-		//task ("When open Accessibility Menu") {
-		//}
-		//task ("Then show underline is set to OFF") {
-		//}
 
 	}
 
@@ -304,7 +227,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When press tab key from 'Skip to Content' link") {
-			AccessibilityMenu.goToAccessibilityMenu();
+			AccessibilityMenu.goToAccessibilityMenuQuickLink();
 		}
 
 		task ("Then Accessibility Menu link is focusable") {
@@ -320,7 +243,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When Accessibility Menu is focused with keyboard") {
-			AccessibilityMenu.goToAccessibilityMenu();
+			AccessibilityMenu.goToAccessibilityMenuQuickLink();
 		}
 
 		task ("And access Accessibility Menu link with 'Enter' key") {

--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
@@ -66,19 +66,144 @@ definition {
 	test ChangedConfigurationSettingByAuthenticatedUserWillBeSavedInDatabase {
 		property portal.acceptance = "true";
 
-		//task ("Given When Then") {
+		task ("Given created new user A") {
 
-		// // Given created new user A
-		// // When sign in as user A
-		// // And toggle show underline to OFF state)
-		// // And sign out
-		// // And guest user sets shows underline configuration to OFF
-		// // And guest user sets shows underline configuration to ON
-		// // And when sign in as user A
-		// // When open Accessibility Menu
-		// // Then show underline is set to OFF
+			JSONUser.addUser(
+				userEmailAddress = "userea@liferay.com",
+				userFirstName = "userfnA",
+				userLastName = "userlnA",
+				userScreenName = "usersnA");
 
-		//}
+		}
+		task ("When sign in as user A") {
+			User.logoutAndLoginPG(
+				userLoginEmailAddress = "userea@liferay.com",
+				userLoginFullName = "userfnA userlnA");
+		}
+
+		task("And toggle an accessibility configuration (underline to OFF state)"){
+			//since it is off by default, I guess you meant to "ON" state, right?
+			AccessibilityMenu.goToAccessibilityMenu();
+
+			KeyPress(
+				key_link = "Accessibility Menu",
+				locator1 = "AccessibilityMenu#QUICK_LINK",
+				value1 = "\ENTER");
+
+			KeyPress(
+				locator1 = "//body",
+				value1 = "\TAB");
+
+			KeyPress(
+				key_modalTitle = "Accessibility Help Menu",
+				locator1 = "Button#CLOSE_MODAL",
+				value1 = "\TAB");
+
+			Check.checkToggleSwitch(
+				key_toggleSwitchLabel = "Underlined Links",
+				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
+			
+		}
+
+		task("And sign out"){
+			SignOut.signOut();
+		}
+		
+		task("And guest user sets shows underline configuration to OFF"){
+			User._login();
+			AccessibilityMenu.goToAccessibilityMenu();
+
+			KeyPress(
+				key_link = "Accessibility Menu",
+				locator1 = "AccessibilityMenu#QUICK_LINK",
+				value1 = "\ENTER");
+
+			KeyPress(
+				locator1 = "//body",
+				value1 = "\TAB");
+
+			KeyPress(
+				key_modalTitle = "Accessibility Help Menu",
+				locator1 = "Button#CLOSE_MODAL",
+				value1 = "\TAB");
+
+			// Check.checkToggleSwitch(
+			// 	key_toggleSwitchLabel = "Underlined Links",
+			// 	locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
+
+		}
+		
+		task("And guest user sets shows underline configuration to ON"){
+			Uncheck.uncheckToggleSwitch(
+				key_toggleSwitchLabel = "Underlined Links",
+				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
+		}
+		task("And when sign in as user A"){
+			User.logoutAndLoginPG(
+				userLoginEmailAddress = "userea@liferay.com",
+				userLoginFullName = "userfnA userlnA");
+		}
+		task("When open Accessibility Menu"){
+			AccessibilityMenu.goToAccessibilityMenu();
+
+			KeyPress(
+				key_link = "Accessibility Menu",
+				locator1 = "AccessibilityMenu#QUICK_LINK",
+				value1 = "\ENTER");
+		}
+		task("Then accessibility configuration states persisted in database for user A"){
+			AssertChecked.assertCheckedNotVisible(
+				key_toggleSwitchLabel = "Underlined Links",
+				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
+			// underline is set to OFF
+		}
+
+
+//---------------------------------- before
+		// task ("When Accessibility Menu is focused with keyboard") {
+		// 	AccessibilityMenu.goToAccessibilityMenu();
+		// }
+
+		// task ("And toggle show underline to OFF state") {
+
+		// 	KeyPress(
+		// 		key_link = "Accessibility Menu",
+		// 		locator1 = "AccessibilityMenu#QUICK_LINK",
+		// 		value1 = "\ENTER");
+
+			
+		// }
+
+
+		// task ("And can navigate to a switch toggle with keyboard") {
+		// 	KeyPress(
+		// 		locator1 = "//body",
+		// 		value1 = "\TAB");
+
+		// 	KeyPress(
+		// 		key_modalTitle = "Accessibility Help Menu",
+		// 		locator1 = "Button#CLOSE_MODAL",
+		// 		value1 = "\TAB");
+
+		// }
+
+		// task ("And sign out") {
+		// 	signOut();
+		// }
+
+		// task ("And guest user sets shows underline configuration to OFF") {
+			
+
+		// }
+
+		// task ("And guest user sets shows underline configuration to ON") {
+		// }
+		// task ("And when sign in as user A") {
+		// }
+		// task ("When open Accessibility Menu") {
+		// }
+		// task ("Then show underline is set to OFF") {
+		// }
 
 	}
 

--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
@@ -93,7 +93,7 @@ definition {
 			SignOut.signOut();
 		}
 
-		task ("And guest user sets shows Expanded Text configuration to ON") {
+		task ("And guest user sets shows Underlined Links configuration to ON") {
 			AccessibilityMenu.openAccessibilityMenu();
 
 			Uncheck.uncheckNotVisible(

--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
@@ -67,22 +67,23 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given created new user A") {
-
 			JSONUser.addUser(
 				userEmailAddress = "userea@liferay.com",
 				userFirstName = "userfnA",
 				userLastName = "userlnA",
 				userScreenName = "usersnA");
-
 		}
+
 		task ("When sign in as user A") {
 			User.logoutAndLoginPG(
 				userLoginEmailAddress = "userea@liferay.com",
 				userLoginFullName = "userfnA userlnA");
 		}
 
-		task("And toggle an accessibility configuration (underline to OFF state)"){
-			//since it is off by default, I guess you meant to "ON" state, right?
+		task ("And toggle an accessibility configuration (underline to OFF state)") {
+
+			// Since it is off by default, I guess you meant to "ON" state, right?
+
 			AccessibilityMenu.goToAccessibilityMenu();
 
 			KeyPress(
@@ -102,15 +103,15 @@ definition {
 			Check.checkToggleSwitch(
 				key_toggleSwitchLabel = "Underlined Links",
 				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
-			
 		}
 
-		task("And sign out"){
+		task ("And sign out") {
 			SignOut.signOut();
 		}
-		
-		task("And guest user sets shows underline configuration to OFF"){
+
+		task ("And guest user sets shows underline configuration to OFF") {
 			User._login();
+
 			AccessibilityMenu.goToAccessibilityMenu();
 
 			KeyPress(
@@ -127,23 +128,25 @@ definition {
 				locator1 = "Button#CLOSE_MODAL",
 				value1 = "\TAB");
 
-			// Check.checkToggleSwitch(
-			// 	key_toggleSwitchLabel = "Underlined Links",
-			// 	locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
+			//Check.checkToggleSwitch(
+			//	key_toggleSwitchLabel = "Underlined Links",
+			//	locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
 
 		}
-		
-		task("And guest user sets shows underline configuration to ON"){
+
+		task ("And guest user sets shows underline configuration to ON") {
 			Uncheck.uncheckToggleSwitch(
 				key_toggleSwitchLabel = "Underlined Links",
 				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
 		}
-		task("And when sign in as user A"){
+
+		task ("And when sign in as user A") {
 			User.logoutAndLoginPG(
 				userLoginEmailAddress = "userea@liferay.com",
 				userLoginFullName = "userfnA userlnA");
 		}
-		task("When open Accessibility Menu"){
+
+		task ("When open Accessibility Menu") {
 			AccessibilityMenu.goToAccessibilityMenu();
 
 			KeyPress(
@@ -151,59 +154,49 @@ definition {
 				locator1 = "AccessibilityMenu#QUICK_LINK",
 				value1 = "\ENTER");
 		}
-		task("Then accessibility configuration states persisted in database for user A"){
+
+		task ("Then accessibility configuration states persisted in database for user A") {
 			AssertChecked.assertCheckedNotVisible(
 				key_toggleSwitchLabel = "Underlined Links",
 				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
-			// underline is set to OFF
+
+			// Underline is set to OFF
+
 		}
 
+		// ---------------------------------- before
 
-//---------------------------------- before
-		// task ("When Accessibility Menu is focused with keyboard") {
-		// 	AccessibilityMenu.goToAccessibilityMenu();
-		// }
-
-		// task ("And toggle show underline to OFF state") {
-
-		// 	KeyPress(
-		// 		key_link = "Accessibility Menu",
-		// 		locator1 = "AccessibilityMenu#QUICK_LINK",
-		// 		value1 = "\ENTER");
-
-			
-		// }
-
-
-		// task ("And can navigate to a switch toggle with keyboard") {
-		// 	KeyPress(
-		// 		locator1 = "//body",
-		// 		value1 = "\TAB");
-
-		// 	KeyPress(
-		// 		key_modalTitle = "Accessibility Help Menu",
-		// 		locator1 = "Button#CLOSE_MODAL",
-		// 		value1 = "\TAB");
-
-		// }
-
-		// task ("And sign out") {
-		// 	signOut();
-		// }
-
-		// task ("And guest user sets shows underline configuration to OFF") {
-			
-
-		// }
-
-		// task ("And guest user sets shows underline configuration to ON") {
-		// }
-		// task ("And when sign in as user A") {
-		// }
-		// task ("When open Accessibility Menu") {
-		// }
-		// task ("Then show underline is set to OFF") {
-		// }
+		//task ("When Accessibility Menu is focused with keyboard") {
+		//	AccessibilityMenu.goToAccessibilityMenu();
+		//}
+		//task ("And toggle show underline to OFF state") {
+		//	KeyPress(
+		//		key_link = "Accessibility Menu",
+		//		locator1 = "AccessibilityMenu#QUICK_LINK",
+		//		value1 = "\ENTER");
+		//}
+		//task ("And can navigate to a switch toggle with keyboard") {
+		//	KeyPress(
+		//		locator1 = "//body",
+		//		value1 = "\TAB");
+		//	KeyPress(
+		//		key_modalTitle = "Accessibility Help Menu",
+		//		locator1 = "Button#CLOSE_MODAL",
+		//		value1 = "\TAB");
+		//}
+		//task ("And sign out") {
+		//	signOut();
+		//}
+		//task ("And guest user sets shows underline configuration to OFF") {
+		//}
+		//task ("And guest user sets shows underline configuration to ON") {
+		//}
+		//task ("And when sign in as user A") {
+		//}
+		//task ("When open Accessibility Menu") {
+		//}
+		//task ("Then show underline is set to OFF") {
+		//}
 
 	}
 

--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
@@ -68,7 +68,6 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given created new user A") {
-			
 			JSONUser.addUser(
 				userEmailAddress = "userea@liferay.com",
 				userFirstName = "userfnA",
@@ -83,7 +82,6 @@ definition {
 		}
 
 		task ("And toggle an accessibility configuration (set underline to ON state)") {
-
 			AccessibilityMenu.openAccessibilityMenu();
 
 			Check.checkNotVisible(
@@ -111,16 +109,13 @@ definition {
 
 		task ("When open Accessibility Menu") {
 			AccessibilityMenu.openAccessibilityMenu();
-
 		}
 
 		task ("Then accessibility configuration states persisted in database for user A") {
 			AssertChecked.assertCheckedNotVisible(
 				key_toggleSwitchLabel = "Underlined Links",
 				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
-
 		}
-
 	}
 
 	@description = "LPS-178192. Verifies accessibility menu modal toggle switches are keyboard accessible."


### PR DESCRIPTION
Description

Given created new user A
And as a guest user with default Accessibility menu configurations
When sign in user A
And toggle an accessibility configuration (underline to OFF state)
And sign out
And guest user sets shows underline configuration to OFF
And guest user sets shows underline configuration to ON
And when sign in as user A
When open Accessibility Menu
Then accessibility configuration states persisted in database for user A
// underline is set to OFF

Note: Some changes were made after some review as you [can see here](https://github.com/eltonccdantas/liferay-portal/pull/14) 

[Ticket](https://liferay.atlassian.net/browse/LPS-187582)