### PR TITLE
LPS-187587 - Add Autom. Test UntoggledSettingsAreAppliedImmediately

### DIFF
--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/paths/AccessibilityMenu.path
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/paths/AccessibilityMenu.path
@@ -21,6 +21,11 @@
 	<td>//*[@class="modal-title"][contains(text(),"${key_modal_title}")]</td>
 	<td></td>
 </tr>
+<tr>
+	<td>BODY_SPECIFIC_CLASS</td>
+	<td>//body[contains(@class, '${key_class}')]</td>
+	<td></td>
+</tr>
 </tbody>
 </table>
 </body>

--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
@@ -384,15 +384,47 @@ definition {
 	test UntoggledSettingsAreAppliedImmediately {
 		property portal.acceptance = "true";
 
-		// Given home page
-		// And underline class is applied to Powered by Liferay
-		// // verify show underline config in accessibility menu is on
-		// // verify link element "Powered by Liferay" does have "c-prefers-link-underline" class present
-		// When access Accessibility Menu
-		// And toggle OFF show underline effect in links
-		// Then Powered by Liferay link does not have underline class applied
-		// // assert link element "Powered by Liferay" does not have "c-prefers-link-underline" class present
+		task ("And underline class is applied to body element") {
+			AccessibilityMenu.openAccessibilityMenu();
 
+			Check.checkToggleSwitch(
+				key_toggleSwitchLabel = "Underlined Links",
+				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
+		}
+
+		task ("verify show underline config in accessibility menu is on") {
+			AssertChecked.assertCheckedNotVisible(
+				key_toggleSwitchLabel = "Underlined Links",
+				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
+		}
+
+		task ("verify body element does have 'c-prefers-link-underline' class present") {
+			var key_class = ${key_class};
+
+			AssertElementPresent(
+				key_class = "c-prefers-link-underline",
+				locator1 = "AccessibilityMenu#BODY_SPECIFIC_CLASS");
+		}
+
+		task ("When access Accessibility Menu") {
+			Navigator.openURL();
+
+			AccessibilityMenu.openAccessibilityMenu();
+		}
+
+		task ("And toggle OFF show underline effect in links") {
+			Uncheck.uncheckToggleSwitch(
+				key_toggleSwitchLabel = "Underlined Links",
+				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
+		}
+
+		task ("Then Powered by Liferay link does not have underline class applied") {
+			var key_class = ${key_class};
+
+			AssertElementNotPresent(
+				key_class = "c-prefers-link-underline",
+				locator1 = "AccessibilityMenu#BODY_SPECIFIC_CLASS");
+		}
 	}
 
 }

--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
@@ -379,7 +379,7 @@ definition {
 
 	}
 
-	@description = "LPS-178192. Verifies only if the setting has never been changed by the user, either when signed in or not signed in, will the default value be displayed.."
+	@description = "LPS-178192. Verifies only if the setting has never been changed by the user, either when signed in or not signed in, will the default value be displayed."
 	@priority = 5
 	test UntoggledSettingsAreAppliedImmediately {
 		property portal.acceptance = "true";

--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
@@ -390,15 +390,11 @@ definition {
 			Check.checkToggleSwitch(
 				key_toggleSwitchLabel = "Underlined Links",
 				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
-		}
 
-		task ("verify show underline config in accessibility menu is on") {
 			AssertChecked.assertCheckedNotVisible(
 				key_toggleSwitchLabel = "Underlined Links",
 				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
-		}
 
-		task ("verify body element does have 'c-prefers-link-underline' class present") {
 			var key_class = ${key_class};
 
 			AssertElementPresent(

--- a/modules/apps/accessibility/test.properties
+++ b/modules/apps/accessibility/test.properties
@@ -1,0 +1,27 @@
+##
+## Modules
+##
+
+    modules.includes.required[relevant]=\
+        apps/accessibility
+
+##
+## Test Batch
+##
+
+    #
+    # Relevant
+    #
+
+    test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
+        (portal.acceptance == true) AND \
+        (\
+            (testray.component.names ~ "Accessibility Menu") OR \
+            (testray.main.component.name ~ "Accessibility Menu")\
+        )
+
+##
+## Testray
+##
+
+    testray.main.component.name=Accessibility Menu


### PR DESCRIPTION
[Ticket](https://liferay.atlassian.net/browse/LPS-187587)

Given home page
And underline class is applied to Powered by Liferay
// verify show underline config in accessibility menu is on
// verify link element "Powered by Liferay" does have "c-prefers-link-underline" class present
When access Accessibility Menu
And toggle OFF show underline effect in links 
Then Powered by Liferay link does not have underline class applied
// assert link element "Powered by Liferay" does not have "c-prefers-link-underline" class present