### PR TITLE
LPS-187577 - Add  Autom. Test ConfigurationCanBeToggledWithKeyboard

### DIFF
--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
@@ -191,22 +191,58 @@ definition {
 	}
 
 	@description = "LPS-178192. Verifies accessibility menu modal toggle switches are keyboard accessible."
-	@ignore = "Test Stub"
 	@priority = 3
 	test ConfigurationCanBeToggledWithKeyboard {
+		task ("Given Accessibility Menu") {
+			AccessibilityMenu.openAccessibilityMenu();
+		}
 
-		//task ("Given When Then") {
+		task ("And show underline configuration is at ON state") {
+			Check.checkNotVisible(
+				key_toggleSwitchLabel = "Underlined Links",
+				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
 
-		// // Given Accessibility Menu
-		// // And show underline configuration is at ON state
-		// // When focus on a configuration toggle with keyboard
-		// // And toggle a configuration with "Enter" key
-		// // Then configuration is toggled to OFF state
-		// // And When toggle configuration with "Enter" key
-		// // Then configuration is toggled to ON state
+			AssertChecked.assertCheckedNotVisible(
+				key_toggleSwitchLabel = "Underlined Links",
+				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
+		}
 
-		//}
+		task ("When focus on a configuration toggle with keyboard") {
+			KeyPress(
+				key_modalTitle = "Accessibility Help Menu",
+				locator1 = "Button#CLOSE_MODAL",
+				value1 = "\TAB");
 
+			AssertElementFocused(
+				checkboxName = "Underlined Links",
+				locator1 = "Checkbox#ANY_CHECKBOX");
+		}
+
+		task ("And toggle a configuration with 'Enter' key") {
+			KeyPress(
+				checkboxName = "Underlined Links",
+				locator1 = "Checkbox#ANY_CHECKBOX",
+				value1 = "\ENTER");
+		}
+
+		task ("Then configuration is toggled to OFF state") {
+			AssertNotChecked.assertNotCheckedNotVisible(
+				key_toggleSwitchLabel = "Underlined Links",
+				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
+		}
+
+		task ("And When toggle configuration with 'Enter' key") {
+			KeyPress(
+				checkboxName = "Underlined Links",
+				locator1 = "Checkbox#ANY_CHECKBOX",
+				value1 = "\ENTER");
+		}
+
+		task ("Then configuration is toggled to ON state") {
+			AssertChecked.assertCheckedNotVisible(
+				key_toggleSwitchLabel = "Underlined Links",
+				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
+		}
 	}
 
 	@description = "LPS-178192. Verifies focus remains on current configuration toggle after toggling."

--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
@@ -209,7 +209,7 @@ definition {
 
 		task ("When focus on a configuration toggle with keyboard") {
 			KeyPress(
-				key_modalTitle = "Accessibility Help Menu",
+				key_modalTitle = "Accessibility Menu",
 				locator1 = "Button#CLOSE_MODAL",
 				value1 = "\TAB");
 
@@ -379,7 +379,7 @@ definition {
 
 		task ("Then Accessibility Menu modal is present") {
 			AssertElementPresent(
-				key_modal_title = "Accessibility Help Menu",
+				key_modal_title = "Accessibility Menu",
 				locator1 = "AccessibilityMenu#MODAL_TITLE");
 		}
 
@@ -389,7 +389,7 @@ definition {
 				value1 = "\TAB");
 
 			KeyPress(
-				key_modalTitle = "Accessibility Help Menu",
+				key_modalTitle = "Accessibility Menu",
 				locator1 = "Button#CLOSE_MODAL",
 				value1 = "\TAB");
 


### PR DESCRIPTION
[Ticket](https://liferay.atlassian.net/browse/LPS-187577)

Given Accessibility Menu
When focus on a configuration toggle with keyboard
And toggle a configuration with "Enter" key
Then configuration is toggled