### PR TITLE
LPS-187586 | Add Autom. Test ShowUnderlineEffectsCanApplyUnderlineClassToLinksImmediately

### DIFF
--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/paths/AccessibilityMenu.path
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/paths/AccessibilityMenu.path
@@ -21,6 +21,11 @@
 	<td>//*[@class="modal-title"][contains(text(),"${key_modal_title}")]</td>
 	<td></td>
 </tr>
+<tr>
+	<td>BODY_SPECIFIC_CLASS</td>
+	<td>//body[contains(@class, '${key_class}')]</td>
+	<td></td>
+</tr>
 </tbody>
 </table>
 </body>

--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
@@ -343,23 +343,49 @@ definition {
 	}
 
 	@description = "LPS-178192. Verifies show underline effects configuration can apply an underline class to link elements in body of page."
-	@ignore = "Test Stub"
 	@priority = 5
 	test ShowUnderlineEffectsCanApplyUnderlineClassToLinksImmediately {
 		property portal.acceptance = "true";
 
-		//task ("Given When Then") {
+		task("Given home page"){
+			Navigator.openURL();
+		}
+		task("And underline class not applied to body element"){
+			AccessibilityMenu.openAccessibilityMenu();
 
-		// // Given home page
-		// // And underline class not applied to body element
-		// // // verify show underline config in accessibility menu is off
-		// // // verify body element does not have "c-prefers-link-underline" class present
-		// // When access Accessibility Menu
-		// // And toggle ON show underline effect in links
-		// // Then body element has underline class applied
-		// // // assert body element has "c-prefers-link-underline" class present
+			AssertNotChecked.assertNotCheckedNotVisible(
+				key_toggleSwitchLabel = "Underlined Links",
+				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
 
-		//}
+			var key_class = ${key_class};
+
+			AssertElementNotPresent(
+				key_class = "c-prefers-link-underline",
+				locator1 = "AccessibilityMenu#BODY_SPECIFIC_CLASS");
+
+		}
+		task("When access Accessibility Menu"){
+			Refresh();
+			AccessibilityMenu.openAccessibilityMenu();
+		}
+		task("And toggle ON show underline effect in links"){
+			Check.checkToggleSwitch(
+				key_toggleSwitchLabel = "Underlined Links",
+				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
+
+		}
+		task("Then body element has underline class applied"){
+
+			AssertChecked.assertCheckedNotVisible(
+				key_toggleSwitchLabel = "Underlined Links",
+				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
+
+			var key_class = ${key_class};
+
+			AssertElementPresent(
+				key_class = "c-prefers-link-underline",
+				locator1 = "AccessibilityMenu#BODY_SPECIFIC_CLASS");
+		}
 
 	}
 

--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
@@ -347,18 +347,12 @@ definition {
 	test ShowUnderlineEffectsCanApplyUnderlineClassToLinksImmediately {
 		property portal.acceptance = "true";
 
-		task ("Given home page") {
-			Navigator.openURL();
-		}
-
 		task ("And underline class not applied to body element") {
 			AccessibilityMenu.openAccessibilityMenu();
 
 			AssertNotChecked.assertNotCheckedNotVisible(
 				key_toggleSwitchLabel = "Underlined Links",
 				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
-
-			var key_class = ${key_class};
 
 			AssertElementNotPresent(
 				key_class = "c-prefers-link-underline",
@@ -378,12 +372,6 @@ definition {
 		}
 
 		task ("Then body element has underline class applied") {
-			AssertChecked.assertCheckedNotVisible(
-				key_toggleSwitchLabel = "Underlined Links",
-				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
-
-			var key_class = ${key_class};
-
 			AssertElementPresent(
 				key_class = "c-prefers-link-underline",
 				locator1 = "AccessibilityMenu#BODY_SPECIFIC_CLASS");

--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
@@ -347,10 +347,11 @@ definition {
 	test ShowUnderlineEffectsCanApplyUnderlineClassToLinksImmediately {
 		property portal.acceptance = "true";
 
-		task("Given home page"){
+		task ("Given home page") {
 			Navigator.openURL();
 		}
-		task("And underline class not applied to body element"){
+
+		task ("And underline class not applied to body element") {
 			AccessibilityMenu.openAccessibilityMenu();
 
 			AssertNotChecked.assertNotCheckedNotVisible(
@@ -362,20 +363,21 @@ definition {
 			AssertElementNotPresent(
 				key_class = "c-prefers-link-underline",
 				locator1 = "AccessibilityMenu#BODY_SPECIFIC_CLASS");
-
 		}
-		task("When access Accessibility Menu"){
+
+		task ("When access Accessibility Menu") {
 			Refresh();
+
 			AccessibilityMenu.openAccessibilityMenu();
 		}
-		task("And toggle ON show underline effect in links"){
+
+		task ("And toggle ON show underline effect in links") {
 			Check.checkToggleSwitch(
 				key_toggleSwitchLabel = "Underlined Links",
 				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
-
 		}
-		task("Then body element has underline class applied"){
 
+		task ("Then body element has underline class applied") {
 			AssertChecked.assertCheckedNotVisible(
 				key_toggleSwitchLabel = "Underlined Links",
 				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
@@ -386,7 +388,6 @@ definition {
 				key_class = "c-prefers-link-underline",
 				locator1 = "AccessibilityMenu#BODY_SPECIFIC_CLASS");
 		}
-
 	}
 
 	@description = "LPS-178192. Verifies show underline effects in links toggle is enabled by default."


### PR DESCRIPTION
[Ticket](https://liferay.atlassian.net/browse/LPS-187586)

Given home page
And underline class not applied to Powered by Liferay
// verify show underline config in accessibility menu is off
// verify link element "Powered by Liferay" does not have "c-prefers-link-underline" class present
When access Accessibility Menu
And toggle ON show underline effect in links 
Then Powered by Liferay link has underline class applied
// assert link element "Powered by Liferay" has "c-prefers-link-underline" class present