### PR TITLE
LPS-187827 | Add Autom. Test GuestConfigurationOnStateWillPersistForFirstLogin

### DIFF
--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/paths/AccessibilityMenu.path
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/paths/AccessibilityMenu.path
@@ -21,6 +21,11 @@
 	<td>//*[@class="modal-title"][contains(text(),"${key_modal_title}")]</td>
 	<td></td>
 </tr>
+<tr>
+	<td>BODY_SPECIFIC_CLASS</td>
+	<td>//body[contains(@class, '${key_class}')]</td>
+	<td></td>
+</tr>
 </tbody>
 </table>
 </body>

--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
@@ -269,7 +269,6 @@ definition {
 	@ignore = "Test Stub"
 	@priority = 3
 	test GuestConfigurationOnStateWillPersistForFirstLogin {
-
 		task ("Given create a new user") {
 			JSONUser.addUser(
 				userEmailAddress = "userea@liferay.com",
@@ -277,9 +276,11 @@ definition {
 				userLastName = "userlnA",
 				userScreenName = "usersnA");
 		}
+
 		task ("And as a guest user") {
 			SignOut.signOut();
 		}
+
 		task ("And toggle show underline to ON state") {
 			AccessibilityMenu.openAccessibilityMenu();
 
@@ -287,25 +288,24 @@ definition {
 				key_toggleSwitchLabel = "Underlined Links",
 				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
 		}
+
 		task ("When sign in as a new user for first time") {
 			User.logoutAndLoginPG(
 				userLoginEmailAddress = "userea@liferay.com",
 				userLoginFullName = "userfnA userlnA");
 		}
+
 		task ("Then configuration is persisted to first time signed in user") {
 			AssertElementPresent(
 				key_class = "c-prefers-link-underline",
 				locator1 = "AccessibilityMenu#BODY_SPECIFIC_CLASS");
-			
+
 			AccessibilityMenu.openAccessibilityMenu();
 
 			AssertChecked.assertCheckedNotVisible(
 				key_toggleSwitchLabel = "Underlined Links",
 				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
-
 		}
-
-
 	}
 
 	@description = "LPS-178192. Verifies accessibility menu quick link is keyboard focusable."

--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
@@ -266,9 +266,10 @@ definition {
 	}
 
 	@description = "LPS-178192. Verifies ON state can persist to first login user."
-	@ignore = "Test Stub"
 	@priority = 3
 	test GuestConfigurationOnStateWillPersistForFirstLogin {
+		property portal.acceptance = "true";
+
 		task ("Given create a new user") {
 			JSONUser.addUser(
 				userEmailAddress = "userea@liferay.com",

--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
@@ -270,21 +270,41 @@ definition {
 	@priority = 3
 	test GuestConfigurationOnStateWillPersistForFirstLogin {
 
-		//task ("Given When Then") {
+		task ("Given create a new user") {
+			JSONUser.addUser(
+				userEmailAddress = "userea@liferay.com",
+				userFirstName = "userfnA",
+				userLastName = "userlnA",
+				userScreenName = "usersnA");
+		}
+		task ("And as a guest user") {
+			SignOut.signOut();
+		}
+		task ("And toggle show underline to ON state") {
+			AccessibilityMenu.openAccessibilityMenu();
 
-		// // Given create a new user
-		// // And as a guest user
-		// // // sign out of admin role to become a guest user role
-		// // And toggle show underline to ON state
-		// // //click show underline to ON state
-		// // When sign in as a new user for first time
-		// // Then configuration is persisted to first time signed in user
-		// // // assert body element has "c-prefers-link-underline" class present
-		// // //open accessibility menu
-		// // // assert configuration is ON state
-		// // Note: may need to remove any underline html attributes. see https://www.w3schools.com/howto/howto_js_remove_class.asp
+			Check.checkNotVisible(
+				key_toggleSwitchLabel = "Underlined Links",
+				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
+		}
+		task ("When sign in as a new user for first time") {
+			User.logoutAndLoginPG(
+				userLoginEmailAddress = "userea@liferay.com",
+				userLoginFullName = "userfnA userlnA");
+		}
+		task ("Then configuration is persisted to first time signed in user") {
+			AssertElementPresent(
+				key_class = "c-prefers-link-underline",
+				locator1 = "AccessibilityMenu#BODY_SPECIFIC_CLASS");
+			
+			AccessibilityMenu.openAccessibilityMenu();
 
-		//}
+			AssertChecked.assertCheckedNotVisible(
+				key_toggleSwitchLabel = "Underlined Links",
+				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
+
+		}
+
 
 	}
 


### PR DESCRIPTION
[Ticket](https://liferay.atlassian.net/browse/LPS-187827)

Given create a new user
And as a guest user
// sign out of admin role to become a guest user role
And toggle show underline to ON state
//click show underline to ON state
When sign in as a new user for first time
Then configuration is persisted to first time signed in user
// assert"c-prefers-link-underline" class present in the body element
//open accessibility menu
// assert configuration is ON state