### PR TITLE
LPS-187581 | Add Autom. Test GuestConfigurationOffStateWillPersistForFirstLogin

### DIFF
--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
@@ -243,25 +243,55 @@ definition {
 	}
 
 	@description = "LPS-178192. Verifies OFF state can persist to first login user."
-	@ignore = "Test Stub"
 	@priority = 3
 	test GuestConfigurationOffStateWillPersistForFirstLogin {
 
-		//task ("Given When Then") {
+		task("Given create a new user"){
+			JSONUser.addUser(
+				userEmailAddress = "userea@liferay.com",
+				userFirstName = "userfnA",
+				userLastName = "userlnA",
+				userScreenName = "usersnA");
+		}
+		task("And as a guest user"){
+			SignOut.signOut();
 
-		// // Given create a new user
-		// // And as a guest user
-		// // // sign out of admin role to become a guest user role
-		// // And toggle show underline to OFF state
-		// // //click show underline to OFF state
-		// // When sign in as a new user for first time
-		// // Then configuration is persisted to first time signed in user
-		// // // assert body element does not have "c-prefers-link-underline" class present
-		// // //open accessibility menu
-		// // // assert configuration is OFF state
-		// // Note: may need to remove any underline html attributes. see https://www.w3schools.com/howto/howto_js_remove_class.asp
 
-		//}
+		}
+		task("And toggle underline is set to ON state"){
+			AccessibilityMenu.openAccessibilityMenu();
+
+			Check.checkToggleSwitch(
+				key_toggleSwitchLabel = "Underlined Links",
+				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
+
+		}
+
+		task("And toggle underline is set to OFF state"){
+			AccessibilityMenu.openAccessibilityMenu();
+
+			Uncheck.uncheckToggleSwitch(
+				key_toggleSwitchLabel = "Underlined Links",
+				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
+		}
+		task("When sign in as a new user for first time"){			
+			User.logoutAndLoginPG(
+				userLoginEmailAddress = "userea@liferay.com",
+				userLoginFullName = "userfnA userlnA");
+		}
+		task("Then configuration is persisted to first time signed in user"){
+			AssertElementNotPresent(
+				key_class = "c-prefers-link-underline",
+				locator1 = "AccessibilityMenu#BODY_SPECIFIC_CLASS");
+
+			AccessibilityMenu.openAccessibilityMenu();
+
+			AssertNotChecked.assertNotCheckedNotVisible(
+				key_toggleSwitchLabel = "Underlined Links",
+				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
+
+		}
+
 
 	}
 

--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
@@ -245,41 +245,41 @@ definition {
 	@description = "LPS-178192. Verifies OFF state can persist to first login user."
 	@priority = 3
 	test GuestConfigurationOffStateWillPersistForFirstLogin {
-
-		task("Given create a new user"){
+		task ("Given create a new user") {
 			JSONUser.addUser(
 				userEmailAddress = "userea@liferay.com",
 				userFirstName = "userfnA",
 				userLastName = "userlnA",
 				userScreenName = "usersnA");
 		}
-		task("And as a guest user"){
+
+		task ("And as a guest user") {
 			SignOut.signOut();
-
-
 		}
-		task("And toggle underline is set to ON state"){
+
+		task ("And toggle underline is set to ON state") {
 			AccessibilityMenu.openAccessibilityMenu();
 
 			Check.checkToggleSwitch(
 				key_toggleSwitchLabel = "Underlined Links",
 				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
-
 		}
 
-		task("And toggle underline is set to OFF state"){
+		task ("And toggle underline is set to OFF state") {
 			AccessibilityMenu.openAccessibilityMenu();
 
 			Uncheck.uncheckToggleSwitch(
 				key_toggleSwitchLabel = "Underlined Links",
 				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
 		}
-		task("When sign in as a new user for first time"){			
+
+		task ("When sign in as a new user for first time") {
 			User.logoutAndLoginPG(
 				userLoginEmailAddress = "userea@liferay.com",
 				userLoginFullName = "userfnA userlnA");
 		}
-		task("Then configuration is persisted to first time signed in user"){
+
+		task ("Then configuration is persisted to first time signed in user") {
 			AssertElementNotPresent(
 				key_class = "c-prefers-link-underline",
 				locator1 = "AccessibilityMenu#BODY_SPECIFIC_CLASS");
@@ -289,10 +289,7 @@ definition {
 			AssertNotChecked.assertNotCheckedNotVisible(
 				key_toggleSwitchLabel = "Underlined Links",
 				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
-
 		}
-
-
 	}
 
 	@description = "LPS-178192. Verifies ON state can persist to first login user."

--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
@@ -370,7 +370,7 @@ definition {
 
 		task ("Then Accessibility Menu modal is present") {
 			AssertElementPresent(
-				key_modal_title = "Accessibility Help Menu",
+				key_modal_title = "Accessibility Menu",
 				locator1 = "AccessibilityMenu#MODAL_TITLE");
 		}
 
@@ -380,7 +380,7 @@ definition {
 				value1 = "\TAB");
 
 			KeyPress(
-				key_modalTitle = "Accessibility Help Menu",
+				key_modalTitle = "Accessibility Menu",
 				locator1 = "Button#CLOSE_MODAL",
 				value1 = "\TAB");
 


### PR DESCRIPTION
[Ticket](https://liferay.atlassian.net/browse/LPS-187581)

Given create a new user
And as a guest user
// sign out of admin role to become a guest user role
And toggle show underline to OFF state
//click show underline to OFF state
When sign in as a new user for first time
Then show underline configuration OFF state is persisted to first time signed in user
// assert link element "Powered by Liferay" does NOT have "c-prefers-link-underline" class
//open accessibility menu
// assert configuration is OFF state