### PR TITLE
LPS-187580 | Add Autom. Test GuestConfigurationWillPersistForFirstLogin

### DIFF
--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
@@ -241,46 +241,6 @@ definition {
 		//}
 
 	}
-	@description = "LPS-178192. Verifies guest configured settings will persist in browser local storage."
-	@priority = 4
-	test GuestConfigurationWillPersistForFirstLogin {
-		property portal.acceptance = "true";
-
-		task("Given guest user"){
-			SignOut.signOut();
-		}
-		task("And new created user"){
-			JSONUser.addUser(
-				userEmailAddress = "userea@liferay.com",
-				userFirstName = "userfnA",
-				userLastName = "userlnA",
-				userScreenName = "usersnA");
-		}
-		task("And toggle an accessibility configuration"){
-			AccessibilityMenu.openAccessibilityMenu();
-
-			Check.checkNotVisible(
-				key_toggleSwitchLabel = "Underlined Links",
-				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
-		}
-		task("When sign in as a new user for first time"){
-			User.logoutAndLoginPG(
-				userLoginEmailAddress = "userea@liferay.com",
-				userLoginFullName = "userfnA userlnA");
-		}
-		task("Then configuration is persisted to first time signed in user"){
-			AssertElementPresent(
-				key_class = "c-prefers-link-underline",
-				locator1 = "AccessibilityMenu#BODY_SPECIFIC_CLASS");
-
-			AccessibilityMenu.openAccessibilityMenu();
-
-			AssertChecked.assertCheckedNotVisible(
-				key_toggleSwitchLabel = "Underlined Links",
-				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
-		}
-
-			}
 
 	@description = "LPS-178192. Verifies OFF state can persist to first login user."
 	@ignore = "Test Stub"
@@ -323,6 +283,50 @@ definition {
 		}
 
 		task ("And toggle show underline to ON state") {
+			AccessibilityMenu.openAccessibilityMenu();
+
+			Check.checkNotVisible(
+				key_toggleSwitchLabel = "Underlined Links",
+				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
+		}
+
+		task ("When sign in as a new user for first time") {
+			User.logoutAndLoginPG(
+				userLoginEmailAddress = "userea@liferay.com",
+				userLoginFullName = "userfnA userlnA");
+		}
+
+		task ("Then configuration is persisted to first time signed in user") {
+			AssertElementPresent(
+				key_class = "c-prefers-link-underline",
+				locator1 = "AccessibilityMenu#BODY_SPECIFIC_CLASS");
+
+			AccessibilityMenu.openAccessibilityMenu();
+
+			AssertChecked.assertCheckedNotVisible(
+				key_toggleSwitchLabel = "Underlined Links",
+				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
+		}
+	}
+
+	@description = "LPS-178192. Verifies guest configured settings will persist in browser local storage."
+	@priority = 4
+	test GuestConfigurationWillPersistForFirstLogin {
+		property portal.acceptance = "true";
+
+		task ("Given guest user") {
+			SignOut.signOut();
+		}
+
+		task ("And new created user") {
+			JSONUser.addUser(
+				userEmailAddress = "userea@liferay.com",
+				userFirstName = "userfnA",
+				userLastName = "userlnA",
+				userScreenName = "usersnA");
+		}
+
+		task ("And toggle an accessibility configuration") {
 			AccessibilityMenu.openAccessibilityMenu();
 
 			Check.checkNotVisible(

--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
@@ -387,7 +387,7 @@ definition {
 
 		task ("Then Accessibility Menu modal is present") {
 			AssertElementPresent(
-				key_modal_title = "Accessibility Help Menu",
+				key_modal_title = "Accessibility Menu",
 				locator1 = "AccessibilityMenu#MODAL_TITLE");
 		}
 
@@ -397,7 +397,7 @@ definition {
 				value1 = "\TAB");
 
 			KeyPress(
-				key_modalTitle = "Accessibility Help Menu",
+				key_modalTitle = "Accessibility Menu",
 				locator1 = "Button#CLOSE_MODAL",
 				value1 = "\TAB");
 

--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
@@ -241,6 +241,46 @@ definition {
 		//}
 
 	}
+	@description = "LPS-178192. Verifies guest configured settings will persist in browser local storage."
+	@priority = 4
+	test GuestConfigurationWillPersistForFirstLogin {
+		property portal.acceptance = "true";
+
+		task("Given guest user"){
+			SignOut.signOut();
+		}
+		task("And new created user"){
+			JSONUser.addUser(
+				userEmailAddress = "userea@liferay.com",
+				userFirstName = "userfnA",
+				userLastName = "userlnA",
+				userScreenName = "usersnA");
+		}
+		task("And toggle an accessibility configuration"){
+			AccessibilityMenu.openAccessibilityMenu();
+
+			Check.checkNotVisible(
+				key_toggleSwitchLabel = "Underlined Links",
+				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
+		}
+		task("When sign in as a new user for first time"){
+			User.logoutAndLoginPG(
+				userLoginEmailAddress = "userea@liferay.com",
+				userLoginFullName = "userfnA userlnA");
+		}
+		task("Then configuration is persisted to first time signed in user"){
+			AssertElementPresent(
+				key_class = "c-prefers-link-underline",
+				locator1 = "AccessibilityMenu#BODY_SPECIFIC_CLASS");
+
+			AccessibilityMenu.openAccessibilityMenu();
+
+			AssertChecked.assertCheckedNotVisible(
+				key_toggleSwitchLabel = "Underlined Links",
+				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
+		}
+
+			}
 
 	@description = "LPS-178192. Verifies OFF state can persist to first login user."
 	@ignore = "Test Stub"


### PR DESCRIPTION
[Ticket](https://liferay.atlassian.net/browse/LPS-187580)

Given guest user
And new created user
And toggle an accessibility configuration
//set show underline to OFF state
When sign in as a new user for first time
Then configuration is persisted to first time signed in user
// assert link in Powered by Liferay is not underlined
//open accessibility menu
// assert configuration is OFF state