### PR TITLE
LPS-191968 Add a featureFlagKey attribute to Meta.OCD and Meta.AD

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/model/ConfigurationModel.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/model/ConfigurationModel.java
@@ -192,6 +192,10 @@ public class ConfigurationModel implements ExtendedObjectClassDefinition {
 		return _extendedObjectClassDefinition.getID();
 	}
 
+	public String getFeatureFlagKey() {
+		return _extensionAttributes.get("featureFlagKey");
+	}
+
 	public Map<String, String> getHintAttributes() {
 		return _extendedObjectClassDefinition.getExtensionAttributes(
 			"http://www.liferay.com/xsd/meta-type-hints_7_0_0");

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationModelToDDMFormConverter.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationModelToDDMFormConverter.java
@@ -555,10 +555,14 @@ public class ConfigurationModelToDDMFormConverter {
 			attributeDefinition);
 
 		if ((configurationScopeDisplayContext != null) &&
-			!ConfigurationVisibilityUtil.isVisibleByVisibilityControllerKey(
-				extensionAttributes.get("visibility-controller-key"),
+			(!ConfigurationVisibilityUtil.isVisibleByFeatureFlagKey(
+				extensionAttributes.get("featureFlagKey"),
 				configurationScopeDisplayContext.getScope(),
-				configurationScopeDisplayContext.getScopePK())) {
+				configurationScopeDisplayContext.getScopePK()) ||
+			 !ConfigurationVisibilityUtil.isVisibleByVisibilityControllerKey(
+				 extensionAttributes.get("visibility-controller-key"),
+				 configurationScopeDisplayContext.getScope(),
+				 configurationScopeDisplayContext.getScopePK()))) {
 
 			ddmFormField.setVisibilityExpression("FALSE");
 		}

--- a/modules/apps/portal-configuration/portal-configuration-metatype-definitions-annotations/src/main/java/com/liferay/portal/configuration/metatype/definitions/annotations/internal/AnnotationsExtendedAttributeDefinition.java
+++ b/modules/apps/portal-configuration/portal-configuration-metatype-definitions-annotations/src/main/java/com/liferay/portal/configuration/metatype/definitions/annotations/internal/AnnotationsExtendedAttributeDefinition.java
@@ -148,6 +148,9 @@ public class AnnotationsExtendedAttributeDefinition
 						StringUtil.merge(
 							extendedAttributeDefinition.descriptionArguments())
 					).put(
+						"featureFlagKey",
+						extendedAttributeDefinition.featureFlagKey()
+					).put(
 						"name-arguments",
 						StringUtil.merge(
 							extendedAttributeDefinition.nameArguments())

--- a/modules/apps/portal-configuration/portal-configuration-metatype-definitions-annotations/src/main/java/com/liferay/portal/configuration/metatype/definitions/annotations/internal/AnnotationsExtendedObjectClassDefinition.java
+++ b/modules/apps/portal-configuration/portal-configuration-metatype-definitions-annotations/src/main/java/com/liferay/portal/configuration/metatype/definitions/annotations/internal/AnnotationsExtendedObjectClassDefinition.java
@@ -195,6 +195,8 @@ public class AnnotationsExtendedObjectClassDefinition
 			"factoryInstanceLabelAttribute",
 			extendedObjectClassDefinition.factoryInstanceLabelAttribute()
 		).put(
+			"featureFlagKey", extendedObjectClassDefinition.featureFlagKey()
+		).put(
 			"generateUI",
 			Boolean.toString(extendedObjectClassDefinition.generateUI())
 		).put(

--- a/modules/apps/static/portal-configuration/portal-configuration-metatype-api/bnd.bnd
+++ b/modules/apps/static/portal-configuration/portal-configuration-metatype-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Configuration Metatype API
 Bundle-SymbolicName: com.liferay.portal.configuration.metatype.api
-Bundle-Version: 6.2.2
+Bundle-Version: 6.3.0
 Export-Package:\
 	com.liferay.portal.configuration.metatype.annotations,\
 	com.liferay.portal.configuration.metatype.bnd.util,\

--- a/modules/apps/static/portal-configuration/portal-configuration-metatype-api/src/main/java/com/liferay/portal/configuration/metatype/annotations/ExtendedAttributeDefinition.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-metatype-api/src/main/java/com/liferay/portal/configuration/metatype/annotations/ExtendedAttributeDefinition.java
@@ -7,6 +7,8 @@ package com.liferay.portal.configuration.metatype.annotations;
 
 import aQute.bnd.annotation.xml.XMLAttribute;
 
+import com.liferay.petra.string.StringPool;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -29,6 +31,8 @@ public @interface ExtendedAttributeDefinition {
 		"http://www.liferay.com/xsd/liferay-configuration-admin_1_0_0.xsd";
 
 	public String[] descriptionArguments() default {};
+
+	public String featureFlagKey() default StringPool.BLANK;
 
 	public String[] nameArguments() default {};
 

--- a/modules/apps/static/portal-configuration/portal-configuration-metatype-api/src/main/java/com/liferay/portal/configuration/metatype/annotations/ExtendedObjectClassDefinition.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-metatype-api/src/main/java/com/liferay/portal/configuration/metatype/annotations/ExtendedObjectClassDefinition.java
@@ -37,6 +37,8 @@ public @interface ExtendedObjectClassDefinition {
 
 	public String factoryInstanceLabelAttribute() default "";
 
+	public String featureFlagKey() default StringPool.BLANK;
+
 	public boolean generateUI() default true;
 
 	public String liferayLearnMessageKey() default "";

--- a/modules/apps/static/portal-configuration/portal-configuration-metatype-api/src/main/resources/com/liferay/portal/configuration/metatype/annotations/packageinfo
+++ b/modules/apps/static/portal-configuration/portal-configuration-metatype-api/src/main/resources/com/liferay/portal/configuration/metatype/annotations/packageinfo
@@ -1,1 +1,1 @@
-version 1.7.0
+version 1.8.0


### PR DESCRIPTION
This is an update for [LPS-191968](https://issues.liferay.com/browse/LPS-191968).

@ethib137 this takes a different approach by adding a dedicated attribute to the extended object/attribute definition annotations.

The dev can add this to the config interface class to control the entire configuration UI visibility with a feature flag:
```
@ExtendedObjectClassDefinition(featureFlagKey = "LPS-179483")
```

The dev can add this to an individual method on the config interface to control visibility on just that field in the UI:
```
@ExtendedAttributeDefinition(featureFlagKey = "LPS-179483")
```

This approach also avoids registering any new services, which was the problem with the visibility controller approach I took earlier.

Please let me know if you have any questions or concerns.

/cc @thiago-buarqque