### PR TITLE
LPS-192353

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -261,7 +261,7 @@ export function FieldBase({
 	const accessiblePropsFields = {
 		...(hasFieldDetails && {'aria-labelledby': fieldDetailsId}),
 		...(showFor && {htmlFor: id ?? name}),
-		...(readFieldDetails && {tabIndex: 0}),
+		...(readFieldDetails && {tabIndex: 0} && {role: 'none'}),
 	};
 
 	const defaultRows = nestedFields?.map((field) => ({


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-192353

The ARC toolkit extension found the following error for the paragraph ddm form field type:
WCAG 2.1: 4.1.2 Name, Role, Value - The element has been placed in the Tab order using tabIndex="0", but it lacks a specific role="..." attribute.

I saw a solution to a similar issue where role: none was added. I tested this and it did make the error go away in the ARC test, but I am not sure if this is the best solution. Please let me know if something needs to be changed for this!
