### PR TITLE
LPS-190946 adds ClayTable markup to FDS

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/TableHeadCell.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/TableHeadCell.js
@@ -77,12 +77,14 @@ function TableHeadCell({
 		>
 			{sortable ? (
 				<ClayButton
-					className="btn-sorting inline-item text-nowrap text-truncate-inline"
+					className="inline-item text-nowrap text-truncate-inline"
 					displayType="unstyled"
 					onClick={handleSortingCellClick}
-					small
+					size="sm"
 				>
-					{!hideColumnLabel && label}
+					{!hideColumnLabel && (
+						<span className="text-truncate">label</span>
+					)}
 
 					<span className="inline-item inline-item-after sorting-icons-wrapper">
 						<ClayIcon

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/TableHeadCell.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/TableHeadCell.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
+import ClayLink from '@clayui/link';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, {useContext, useEffect, useState} from 'react';
@@ -76,36 +76,28 @@ function TableHeadCell({
 			resizable
 		>
 			{sortable ? (
-				<ClayButton
-					className="inline-item text-nowrap text-truncate-inline"
-					displayType="unstyled"
+				<ClayLink
+					className="inline-item text-truncate-inline"
+					href="#"
 					onClick={handleSortingCellClick}
-					size="sm"
 				>
 					{!hideColumnLabel && (
 						<span className="text-truncate">label</span>
 					)}
 
-					<span className="inline-item inline-item-after sorting-icons-wrapper">
-						<ClayIcon
-							className={classNames(
-								'sorting-icon',
-								sortingMatch?.direction === 'asc' && 'active'
-							)}
-							draggable
-							symbol="order-arrow-up"
-						/>
-
-						<ClayIcon
-							className={classNames(
-								'sorting-icon',
-								sortingMatch?.direction === 'desc' && 'active'
-							)}
-							draggable
-							symbol="order-arrow-down"
-						/>
-					</span>
-				</ClayButton>
+					{sortingMatch && (
+						<span className="inline-item inline-item-after">
+							<ClayIcon
+								draggable
+								symbol={
+									sortingMatch?.direction === 'asc'
+										? 'order-arrow-up'
+										: 'order-arrow-down'
+								}
+							/>
+						</span>
+					)}
+				</ClayLink>
 			) : (
 				!hideColumnLabel && label
 			)}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Cell.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Cell.js
@@ -84,7 +84,7 @@ function Cell({children, className, columnName, heading, resizable}) {
 			headingCell={heading}
 			ref={cellRef}
 			style={{
-				width,
+				width: width ?? 'auto',
 			}}
 		>
 			{children}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Cell.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Cell.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayTable from '@clayui/table';
 import classNames from 'classnames';
 import {throttle} from 'frontend-js-web';
 import PropTypes from 'prop-types';
@@ -78,8 +79,9 @@ function Cell({children, className, columnName, heading, resizable}) {
 	}, [isFixed, modifiedFields, columnName]);
 
 	return (
-		<div
-			className={classNames(heading ? 'dnd-th' : 'dnd-td', className)}
+		<ClayTable.Cell
+			className={classNames(className)}
+			headingCell={heading}
 			ref={cellRef}
 			style={{
 				width,
@@ -96,7 +98,7 @@ function Cell({children, className, columnName, heading, resizable}) {
 					onMouseDown={initializeDrag}
 				/>
 			)}
-		</div>
+		</ClayTable.Cell>
 	);
 }
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Row.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Row.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayTable from '@clayui/table';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, {useContext, useMemo} from 'react';
@@ -43,11 +44,11 @@ function Row({children, className, paddingLeftCells}) {
 	}
 
 	return (
-		<div className={classNames('dnd-tr', className)} style={style}>
+		<ClayTable.Row className={classNames(className)} style={style}>
 			{placeholderPaddingCells}
 
 			{children}
-		</div>
+		</ClayTable.Row>
 	);
 }
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Table.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Table.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayTable from '@clayui/table';
 import classNames from 'classnames';
 import React, {useContext, useLayoutEffect, useRef} from 'react';
 
@@ -21,19 +22,21 @@ function Table({children, className}) {
 	}, [updateTableWidth]);
 
 	return (
-		<div
+		<ClayTable
 			className={classNames(
-				'dnd-table',
 				{
-					'fixed': isFixed,
 					'is-dragging': draggingColumnName !== null,
 				},
 				className
 			)}
 			ref={dndTableRef}
+			style={{
+				tableLayout: isFixed ? 'fixed' : 'auto',
+			}}
+			tableVerticalAlignment="middle"
 		>
 			{children}
-		</div>
+		</ClayTable>
 	);
 }
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/index.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/index.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayTable from '@clayui/table';
 import classNames from 'classnames';
 import React from 'react';
 
@@ -12,11 +13,19 @@ import Row from './Row';
 import Table from './Table';
 
 function Body({children, className}) {
-	return <div className={classNames('dnd-tbody', className)}>{children}</div>;
+	return (
+		<ClayTable.Body className={classNames(className)}>
+			{children}
+		</ClayTable.Body>
+	);
 }
 
 function Head({children, className}) {
-	return <div className={classNames('dnd-thead', className)}>{children}</div>;
+	return (
+		<ClayTable.Head className={classNames(className)}>
+			{children}
+		</ClayTable.Head>
+	);
 }
 
 export default Object.assign(Table, {


### PR DESCRIPTION
Ticket [LPS-190946](https://liferay.atlassian.net/browse/LPS-190946)

Well, basically adding the ClayTable component to the FDS doesn't seem to be a big problem; we'd just have to make some tweaks to some CSS tweaking mechanisms. I'll describe some more details I found, but that doesn't stop us from using ClayTable; it just needs a little more work to adjust.

### Columns Resizer

Basically, it affects a bit how Resizer works, but this is due to the default display classes of each element that deal differently with the adjustment of columns in the table compared to using `flex`, for example, to simulate a table.

One option would be, in the case of the resizer, we could allow it to use `flex` instead of the default table display; it's easier to make the resizer behave smoother.

Here is a comparison when starting the FDS with different markup. Note that even the table with `layout-layout: fixed`, when rendering for the first time, the table auto balances the width of the columns; this is the native behavior. The table using flex has a different behavior when balancing the columns than the table that will try to balance the columns equally.

| Clay Markup | FDS Markup |
|--------|--------|
| ![Screenshot 2023-08-03 at 16 38 30](https://github.com/liferay-peds/liferay-portal/assets/13750819/f2fc490e-0945-4691-b43e-c49a0b631821) | ![Screenshot 2023-08-03 at 16 29 58](https://github.com/liferay-peds/liferay-portal/assets/13750819/f1675f3b-9033-41f4-8e92-9a5cbfd4cf26) | 

To make this work maybe closer to what is expected with the use of `flex`, we can set the `width` to the value of `auto` on the first render. This is the result

![Screenshot 2023-08-03 at 16 45 53](https://github.com/liferay-peds/liferay-portal/assets/13750819/8099bddd-ff94-4230-a150-b455f563e969)

For the last column of actions, we could even define an initial `width` of `64px` to have the same behavior as `flex`.

### CSS

Need to make some tweaks to the existing FDS CSS to behave better with ClayTable, but they are minimal. For example, the monospaced button in the header of the table drastically increases the height of the heading. I believe this is not expected, so we would have to adjust this in Clay.

Another detail is the sorting icons. The sorting icon is duplicated instead of using just one to have the expected Lexicon behavior. This change would have to be made in the FDS. I made some adjustments to this in the POC to have the behaviors that are predicted by the Lexicon. When hovering the mouse over the heading with sorting, the text is marked with an underline, as in the image example

![Screenshot 2023-08-03 at 17 07 23](https://github.com/liferay-peds/liferay-portal/assets/13750819/69d68bcc-ebe6-4236-8793-89f0b67261a9)

### Accessibility

As we are using Clay markup with native browser elements, we have accessibility to a certain extent, but not all features. For example, the resizer does not have accessibility. We would need to work on adding assertiveness for screen readers and interactions via the keyboard. This work would need to be done on top of this, along with the live announcer mechanism to announce resizer changes to the screen readers.

There is also another detail: if we have nested table support, it would be necessary to change all the table accessibility rules to treegrid. This would require additional effort, which we could address in Clay, as it would also involve adding interactions via the keyboard.

In case we add drag and drop of columns or rows, we would also need to add accessibility, as well as interactions via the keyboard and announcements to screen readers, similar to what we do for TreeView. Looking at the FDS code, it appears that this functionality doesn't exist, so I'm not sure if it's something we want to proceed now, given its complexity.

### Considerations

Apparently we don't have any major problems using ClayTable in FDS, we would just need to make CSS adjustments both on FDS and Clay side for some edge cases.

Since the intention is that the FDS adds nested table support, it will require a lot more work here, both considering accessibility and perhaps other CSS tweaks. I believe that we could start to develop some things on the Clay side. For example, column resizer directly in ClayTable and maybe drag-and-drop functionality