### PR TITLE
LPS-193580 Remove fixed height on sign in modal

### DIFF
--- a/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/view.jsp
@@ -135,7 +135,6 @@
 						containerProps: {
 							className: '',
 						},
-						height: '400px',
 						onClose: function () {
 							loading = false;
 							redirect = false;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-193580

This allows the sign in modal to grow without overflow if the content is short enough to fit in the window. With the fixed height, even a small change like font-size: 16px, it will show a scrollbar.

![signinmodal](https://github.com/liferay-peds/liferay-portal/assets/788266/11c5ca50-780a-4607-bdc2-c5b337653d18)
