### PR TITLE
LPS-185844 Add Autom. Test| AddCalendarAccessibility#AddCalendarContentMustBeVisibleAt200Zoom

### DIFF
--- a/modules/apps/calendar/calendar-web-test/src/testFunctional/tests/AddCalendarAccessibility.testcase
+++ b/modules/apps/calendar/calendar-web-test/src/testFunctional/tests/AddCalendarAccessibility.testcase
@@ -1,6 +1,9 @@
 @component-name = "portal-calendar"
 definition {
 
+	property portal.accessibility = "true";
+	property portal.release = "true";
+	property portal.upstream = "true";
 	property testray.main.component.name = "Calendar";
 
 	var pageName = "Calendar Page";
@@ -49,7 +52,7 @@ definition {
 		}
 	}
 
-	@description = "LPS-185844 Verifies that 'More Options' button is available after applying 200% zoom in to the page."
+	@description = "LPS-185844 Verifies that the last scrollable element is not hidden by modal footer at 200% page zoom."
 	@priority = 3
 	test AddCalendarContentMustBeVisibleAt200Zoom {
 		task ("When access add a new calendar modal") {
@@ -60,8 +63,10 @@ definition {
 			BrowserZoom.setZoomTo200();
 		}
 
-		task ("And scroll all the way down") {
-			ScrollBy(value1 = "0, 1000");
+		task ("And scroll more options button into view") {
+			ScrollWebElementIntoView(
+				key_text = "More Options",
+				locator1 = "Button#ANY_SECONDARY");
 		}
 
 		task ("Then More options role is visible") {

--- a/modules/apps/calendar/calendar-web-test/src/testFunctional/tests/AddCalendarAccessibility.testcase
+++ b/modules/apps/calendar/calendar-web-test/src/testFunctional/tests/AddCalendarAccessibility.testcase
@@ -1,0 +1,74 @@
+@component-name = "portal-calendar"
+definition {
+
+	property testray.main.component.name = "Calendar";
+
+	var pageName = "Calendar Page";
+	var portletName = "Calendar";
+
+	setUp {
+		var portalURL = PropsUtil.get("portal.url");
+
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		task ("Given calendar portlet") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Calendar Page");
+
+			JSONLayout.updateLayoutTemplateOfPublicLayout(
+				groupName = "Guest",
+				layoutName = "Calendar Page",
+				layoutTemplate = "1 Column");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "Calendar Page",
+				widgetName = "Calendar");
+
+			Navigator.openSpecificURL(url = "${portalURL}/web/guest/calendar-page");
+		}
+	}
+
+	tearDown {
+		var testLiferayVirtualInstance = PropsUtil.get("test.liferay.virtual.instance");
+
+		if (${testLiferayVirtualInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			Navigator.gotoPage(pageName = "Calendar Page");
+
+			JSONCalendar.tearDown();
+
+			CalendarConfiguration.tearDown();
+
+			PagesAdmin.tearDownCP();
+		}
+	}
+
+	@description = "LPS-185844 Verifies that 'More Options' button is available after applying 200% zoom in to the page."
+	@priority = 3
+	test AddCalendarContentMustBeVisibleAt200Zoom {
+		task ("When access add a new calendar modal") {
+			CalendarNavigator.gotoAddMyCalendars();
+		}
+
+		task ("And zoom in on the page to 200%") {
+			BrowserZoom.setZoomTo200();
+		}
+
+		task ("And scroll all the way down") {
+			ScrollBy(value1 = "0, 1000");
+		}
+
+		task ("Then More options role is visible") {
+			AssertVisible(
+				key_text = "More Options",
+				locator1 = "Button#ANY_SECONDARY");
+		}
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/BrowserZoom.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/BrowserZoom.macro
@@ -1,0 +1,13 @@
+definition {
+
+	macro resetZoom {
+		RobotType.robotTypeShortcut(locator1 = "Ctrl + 0");
+	}
+
+	macro setZoomTo200 {
+		BrowserZoom.resetZoom();
+
+		RobotType.robotTypeShortcut(locator1 = "Ctrl + + + + + + + + + +");
+	}
+
+}


### PR DESCRIPTION
[Ticket](https://liferay.atlassian.net/browse/LPS-185844)

Minimum Requirements:

Determine browser size at 200% zoom to reproduce the issue

Create poshi test that can simulate the browser zoom and size

When modal is scrolled all the way down, assert bottom element is visible

Reference:

https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-scale.html

 

Test Scenario:

Given calendar portlet
When access add a new calendar modal
And zoom in on the page to 200%
And scroll all the way down
Then More options role is visible