### PR TITLE
LPS-194951 Added menu role to selection field type.

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Select/VisibleSelectInput.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Select/VisibleSelectInput.es.js
@@ -95,6 +95,7 @@ const VisibleSelectInput = forwardRef(
 					)}
 					disabled={readOnly}
 					id={id}
+					role="menu"
 					tabIndex="0"
 				>
 					{isValueEmpty || (value.length === 1 && !multiple) ? (


### PR DESCRIPTION
This is for https://liferay.atlassian.net/browse/LPP-50662 which is similar to https://liferay.atlassian.net/browse/LPP-50356 where it was determined that a role did not need to be added and the tabIndex should be removed (https://github.com/liferay-peds/liferay-portal/pull/197)

It looks like in this case though, the tabIndex is added to the single selection form field which should be focusable, as it is possible for that field to be required. 

@ethib137 I wanted to confirm for this circumstance is the best solution to add a role instead of removing tabIndex? I added the role "menu" but also not sure if that is right for this context. 