### PR TITLE
LPS-195844

### DIFF
--- a/modules/apps/product-navigation/product-navigation-control-menu-impl/src/main/java/com/liferay/product/navigation/control/menu/internal/manager/ProductNavigationControlMenuManagerImpl.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-impl/src/main/java/com/liferay/product/navigation/control/menu/internal/manager/ProductNavigationControlMenuManagerImpl.java
@@ -105,6 +105,14 @@ public class ProductNavigationControlMenuManagerImpl
 		try {
 			User user = _portal.getUser(httpServletRequest);
 
+			if (user == null) {
+				ThemeDisplay themeDisplay =
+					(ThemeDisplay)httpServletRequest.getAttribute(
+						WebKeys.THEME_DISPLAY);
+
+				user = themeDisplay.getUser();
+			}
+
 			if ((user == null) || user.isGuestUser()) {
 				return true;
 			}

--- a/modules/apps/product-navigation/product-navigation-control-menu-impl/src/main/java/com/liferay/product/navigation/control/menu/internal/manager/ProductNavigationControlMenuManagerImpl.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-impl/src/main/java/com/liferay/product/navigation/control/menu/internal/manager/ProductNavigationControlMenuManagerImpl.java
@@ -12,6 +12,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -43,7 +44,8 @@ public class ProductNavigationControlMenuManagerImpl
 				Constants.PREVIEW,
 				ParamUtil.getString(
 					httpServletRequest, "p_l_mode", Constants.VIEW)) ||
-			_isLockedLayoutView(httpServletRequest)) {
+			_isLockedLayoutView(httpServletRequest) ||
+			_isGuestUser(httpServletRequest)) {
 
 			return false;
 		}
@@ -97,6 +99,24 @@ public class ProductNavigationControlMenuManagerImpl
 		}
 
 		return true;
+	}
+
+	private boolean _isGuestUser(HttpServletRequest httpServletRequest) {
+		try {
+			User user = _portal.getUser(httpServletRequest);
+
+			if ((user == null) || user.isGuestUser()) {
+				return true;
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to determine if user is guest user", exception);
+			}
+		}
+
+		return false;
 	}
 
 	private boolean _isLockedLayoutView(HttpServletRequest httpServletRequest) {

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -5,9 +5,12 @@
 
 package com.liferay.portal.upgrade.v7_4_x;
 
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.upgrade.BaseExternalReferenceCodeUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.CTModelUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeProcess;
+import com.liferay.portal.kernel.upgrade.GuestUnsupportedResourceActionsUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.kernel.upgrade.util.UpgradeModulesFactory;
 import com.liferay.portal.kernel.upgrade.util.UpgradeVersionTreeMap;
@@ -322,6 +325,12 @@ public class PortalUpgradeProcessRegistryImpl
 			new UpgradePartitionedControlTable("ClassName_"),
 			UpgradeModulesFactory.create(
 				new String[] {"com.liferay.comment.web"}, null));
+
+		upgradeVersionTreeMap.put(
+			new Version(27, 0, 1),
+			new GuestUnsupportedResourceActionsUpgradeProcess(
+				Group.class.getName(), ActionKeys.CONFIGURE_PORTLETS,
+				ActionKeys.VIEW_SITE_ADMINISTRATION));
 	}
 
 }

--- a/portal-impl/src/resource-actions/portal.xml
+++ b/portal-impl/src/resource-actions/portal.xml
@@ -83,6 +83,7 @@
 				<action-key>ASSIGN_DEFAULT_LAYOUT_UTILITY_PAGE_ENTRY</action-key>
 				<action-key>ASSIGN_MEMBERS</action-key>
 				<action-key>ASSIGN_USER_ROLES</action-key>
+				<action-key>CONFIGURE_PORTLETS</action-key>
 				<action-key>DELETE</action-key>
 				<action-key>EXPORT_IMPORT_LAYOUTS</action-key>
 				<action-key>EXPORT_IMPORT_PORTLET_INFO</action-key>
@@ -99,6 +100,7 @@
 				<action-key>UPDATE</action-key>
 				<action-key>VIEW</action-key>
 				<action-key>VIEW_MEMBERS</action-key>
+				<action-key>VIEW_SITE_ADMINISTRATION</action-key>
 				<action-key>VIEW_STAGING</action-key>
 			</guest-unsupported>
 		</permissions>

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/GuestUnsupportedResourceActionsUpgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/GuestUnsupportedResourceActionsUpgradeProcess.java
@@ -1,0 +1,149 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.upgrade;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Michael Bowerman
+ */
+public class GuestUnsupportedResourceActionsUpgradeProcess
+	extends UpgradeProcess {
+
+	public GuestUnsupportedResourceActionsUpgradeProcess(
+		String resourceName, String... guestUnsupportedResourceActions) {
+
+		_resourceName = resourceName;
+		_guestUnsupportedResourceActions = guestUnsupportedResourceActions;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		long bitmask = _getBitmask();
+
+		CompanyLocalServiceUtil.forEachCompanyId(
+			companyId -> _removeGuestUnsupportedResourceActionsPermissions(
+				bitmask, companyId));
+	}
+
+	private long _getBitmask() throws Exception {
+		long bitmask = 0xFFFFFFFFFFFFFFFFL;
+
+		StringBundler sb = new StringBundler(
+			2 + _guestUnsupportedResourceActions.length);
+
+		sb.append("select bitwiseValue from ResourceAction where name = ? ");
+		sb.append("and (");
+
+		for (int i = 1; i < _guestUnsupportedResourceActions.length; i++) {
+			sb.append("actionId = ? or ");
+		}
+
+		sb.append("actionId = ?)");
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				sb.toString())) {
+
+			preparedStatement.setString(1, _resourceName);
+
+			for (int i = 0; i < _guestUnsupportedResourceActions.length; i++) {
+				preparedStatement.setString(
+					i + 2, _guestUnsupportedResourceActions[i]);
+			}
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					bitmask &= ~resultSet.getLong("bitwiseValue");
+				}
+			}
+		}
+
+		return bitmask;
+	}
+
+	private long _getGuestRoleId(long companyId) throws Exception {
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select roleId from Role_ where companyId = ? and name = ?")) {
+
+			preparedStatement.setLong(1, companyId);
+			preparedStatement.setString(2, RoleConstants.GUEST);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				if (!resultSet.next()) {
+					throw new IllegalStateException(
+						"Unable to find Guest role for company " + companyId);
+				}
+
+				return resultSet.getLong("roleId");
+			}
+		}
+	}
+
+	private void _removeGuestUnsupportedResourceActionsPermissions(
+			long bitmask, long companyId)
+		throws Exception {
+
+		long guestRoleId = _getGuestRoleId(companyId);
+
+		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
+				"select resourcePermissionId, actionIds from " +
+					"ResourcePermission where companyId = ? and name = ? and " +
+						"roleId = ?")) {
+
+			preparedStatement1.setLong(1, companyId);
+			preparedStatement1.setString(2, _resourceName);
+			preparedStatement1.setLong(3, guestRoleId);
+
+			try (ResultSet resultSet = preparedStatement1.executeQuery();
+				PreparedStatement preparedStatement2 =
+					AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+						connection,
+						"update ResourcePermission set actionIds = ? where " +
+							"resourcePermissionId = ?")) {
+
+				while (resultSet.next()) {
+					preparedStatement2.setLong(
+						1, resultSet.getLong("actionIds") & bitmask);
+					preparedStatement2.setLong(
+						2, resultSet.getLong("resourcePermissionId"));
+
+					preparedStatement2.addBatch();
+				}
+
+				preparedStatement2.executeBatch();
+			}
+		}
+
+		if (!ArrayUtil.contains(
+				_guestUnsupportedResourceActions, ActionKeys.VIEW)) {
+
+			return;
+		}
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"update ResourcePermission set viewActionId = 0 where " +
+					"companyId = ? and name = ? and roleId = ?")) {
+
+			preparedStatement.setLong(1, companyId);
+			preparedStatement.setString(2, _resourceName);
+			preparedStatement.setLong(3, guestRoleId);
+
+			preparedStatement.executeUpdate();
+		}
+	}
+
+	private final String[] _guestUnsupportedResourceActions;
+	private final String _resourceName;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/packageinfo
@@ -1,1 +1,1 @@
-version 21.2.0
+version 21.3.0


### PR DESCRIPTION
Re-sending from https://github.com/liferay-peds/liferay-portal/pull/253, which has already been approved but needed to be re-sent due to a rebase error. I have rebased it to the latest master and re-sent it here.

Original comment:
> # Motivation
> It is possible to set the Site Settings > Site: View Site and Asset Library Administration Menu permission for the Guest role. If you do so, then Liferay will run the logic to try to render the Control Menu for the Guest user, because it detects that the Site Administration Menu should be visible to them.
> 
> This results in a NullPointerException being thrown any time the Guest user does anything on the Site. This issue started occurring after [LPS-172659](https://liferay.atlassian.net/browse/LPS-172659), because [LPS-172659](https://liferay.atlassian.net/browse/LPS-172659) changed the logic of how we decide to render the Product Navigation Menu vs rendering the Pages Tree in the Control Menu. Prior to [LPS-172659](https://liferay.atlassian.net/browse/LPS-172659), we would decide to render neither the Product Navigation Menu nor the Pages Tree for the Guest user in this scenario. After [LPS-172659](https://liferay.atlassian.net/browse/LPS-172659), we now render the Product Navigation Menu for the Guest user in this scenario. This results in a NullPointerException being thrown, since we rightly don’t anticipate the possibility of attempting to render the Product Navigation Menu for the Guest user.
> 
> See ticket here: [LPS-195844](https://liferay.atlassian.net/browse/LPS-195844)
> 
> # Proposed Solution
> First, I added logic to always refuse to show the Product Navigation Menu if the user is the Guest user. This ensures that if we ever accidentally expose a Control Panel Key's View permission to the Guest user, we still do not render the Product Navigation Menu for them.
> 
> Second, I moved the "View Site and Asset Library Administration" permission, along with the "Configure Portlets" permission, to guest-unsupported, to ensure that the Guest cannot be allowed to have these permissions. I also added the upgrade process to remove these permissions from the Guest role in case if the Guest role was already granted them.
> 
> # Steps to Verify
> 1. Start up Liferay and log in as the admin user.
> 2. Add the Site Settings > Site: View Site and Asset Library Administration Menu permission to the Guest role.
> 3. Log out and visit the portal as a Guest user.
> 
> **Expected Result:** There would be no errors in the logs.
> **Actual Result:** The following error occurs in the logs: https://gist.github.com/mbowerman/b2db1ec2e593d732d9319e082160f0c6