### PR TITLE
LPS-190240 - Show Release section before Beta Section so that it opens first when visiting Instance Settings>>Feature Flags

### DIFF
--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/configuration/admin/category/FeatureFlagConfigurationCategory.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/configuration/admin/category/FeatureFlagConfigurationCategory.java
@@ -51,13 +51,15 @@ public class FeatureFlagConfigurationCategory implements ConfigurationCategory {
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
-		for (FeatureFlagType featureFlagType : FeatureFlagType.values()) {
+		for (int i = 0; i < _orderedFeatureFlagTypes.length; i++) {
+			FeatureFlagType featureFlagType = _orderedFeatureFlagTypes[i];
+
 			_serviceRegistrations.add(
 				bundleContext.registerService(
 					ConfigurationScreen.class,
 					new FeatureFlagConfigurationScreen(
 						_featureFlagManager, featureFlagType,
-						_featureFlagsDisplayContextFactory,
+						_featureFlagsDisplayContextFactory, i,
 						ExtendedObjectClassDefinition.Scope.SYSTEM.getValue(),
 						_servletContext),
 					new HashMapDictionary<>()));
@@ -67,7 +69,7 @@ public class FeatureFlagConfigurationCategory implements ConfigurationCategory {
 					ConfigurationScreen.class,
 					new FeatureFlagConfigurationScreen(
 						_featureFlagManager, featureFlagType,
-						_featureFlagsDisplayContextFactory,
+						_featureFlagsDisplayContextFactory, i,
 						ExtendedObjectClassDefinition.Scope.COMPANY.getValue(),
 						_servletContext),
 					new HashMapDictionary<>()));
@@ -80,6 +82,11 @@ public class FeatureFlagConfigurationCategory implements ConfigurationCategory {
 
 		_serviceRegistrations.clear();
 	}
+
+	private static final FeatureFlagType[] _orderedFeatureFlagTypes = {
+		FeatureFlagType.RELEASE, FeatureFlagType.BETA,
+		FeatureFlagType.DEPRECATION, FeatureFlagType.DEV
+	};
 
 	@Reference
 	private FeatureFlagManager _featureFlagManager;

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/configuration/admin/category/FeatureFlagConfigurationCategory.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/configuration/admin/category/FeatureFlagConfigurationCategory.java
@@ -10,7 +10,6 @@ import com.liferay.configuration.admin.display.ConfigurationScreen;
 import com.liferay.feature.flag.web.internal.configuration.admin.display.FeatureFlagConfigurationScreen;
 import com.liferay.feature.flag.web.internal.display.FeatureFlagsDisplayContextFactory;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
-import com.liferay.portal.kernel.feature.flag.FeatureFlagManager;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagType;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 
@@ -58,8 +57,7 @@ public class FeatureFlagConfigurationCategory implements ConfigurationCategory {
 				bundleContext.registerService(
 					ConfigurationScreen.class,
 					new FeatureFlagConfigurationScreen(
-						_featureFlagManager, featureFlagType,
-						_featureFlagsDisplayContextFactory, i,
+						featureFlagType, _featureFlagsDisplayContextFactory, i,
 						ExtendedObjectClassDefinition.Scope.SYSTEM.getValue(),
 						_servletContext),
 					new HashMapDictionary<>()));
@@ -68,8 +66,7 @@ public class FeatureFlagConfigurationCategory implements ConfigurationCategory {
 				bundleContext.registerService(
 					ConfigurationScreen.class,
 					new FeatureFlagConfigurationScreen(
-						_featureFlagManager, featureFlagType,
-						_featureFlagsDisplayContextFactory, i,
+						featureFlagType, _featureFlagsDisplayContextFactory, i,
 						ExtendedObjectClassDefinition.Scope.COMPANY.getValue(),
 						_servletContext),
 					new HashMapDictionary<>()));
@@ -87,9 +84,6 @@ public class FeatureFlagConfigurationCategory implements ConfigurationCategory {
 		FeatureFlagType.RELEASE, FeatureFlagType.BETA,
 		FeatureFlagType.DEPRECATION, FeatureFlagType.DEV
 	};
-
-	@Reference
-	private FeatureFlagManager _featureFlagManager;
 
 	@Reference
 	private FeatureFlagsDisplayContextFactory

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/configuration/admin/display/FeatureFlagConfigurationScreen.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/configuration/admin/display/FeatureFlagConfigurationScreen.java
@@ -32,11 +32,12 @@ public class FeatureFlagConfigurationScreen implements ConfigurationScreen {
 	public FeatureFlagConfigurationScreen(
 		FeatureFlagManager featureFlagManager, FeatureFlagType featureFlagType,
 		FeatureFlagsDisplayContextFactory featureFlagsDisplayContextFactory,
-		String scope, ServletContext servletContext) {
+		int index, String scope, ServletContext servletContext) {
 
 		_featureFlagManager = featureFlagManager;
 		_featureFlagType = featureFlagType;
 		_featureFlagsDisplayContextFactory = featureFlagsDisplayContextFactory;
+		_index = index;
 		_scope = scope;
 		_servletContext = servletContext;
 	}
@@ -49,7 +50,7 @@ public class FeatureFlagConfigurationScreen implements ConfigurationScreen {
 	@Override
 	public String getKey() {
 		return FeatureFlagConstants.getKey(
-			_featureFlagType.toString(), getScope());
+			String.valueOf(_index), _featureFlagType.toString(), getScope());
 	}
 
 	@Override
@@ -101,6 +102,7 @@ public class FeatureFlagConfigurationScreen implements ConfigurationScreen {
 	private final FeatureFlagsDisplayContextFactory
 		_featureFlagsDisplayContextFactory;
 	private final FeatureFlagType _featureFlagType;
+	private final int _index;
 	private final String _scope;
 	private final ServletContext _servletContext;
 

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/configuration/admin/display/FeatureFlagConfigurationScreen.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/configuration/admin/display/FeatureFlagConfigurationScreen.java
@@ -9,7 +9,6 @@ import com.liferay.configuration.admin.display.ConfigurationScreen;
 import com.liferay.feature.flag.web.internal.configuration.admin.category.FeatureFlagConfigurationCategory;
 import com.liferay.feature.flag.web.internal.display.FeatureFlagsDisplayContextFactory;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
-import com.liferay.portal.kernel.feature.flag.FeatureFlagManager;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagType;
 import com.liferay.portal.kernel.feature.flag.constants.FeatureFlagConstants;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -30,11 +29,10 @@ import javax.servlet.http.HttpServletResponse;
 public class FeatureFlagConfigurationScreen implements ConfigurationScreen {
 
 	public FeatureFlagConfigurationScreen(
-		FeatureFlagManager featureFlagManager, FeatureFlagType featureFlagType,
+		FeatureFlagType featureFlagType,
 		FeatureFlagsDisplayContextFactory featureFlagsDisplayContextFactory,
 		int index, String scope, ServletContext servletContext) {
 
-		_featureFlagManager = featureFlagManager;
 		_featureFlagType = featureFlagType;
 		_featureFlagsDisplayContextFactory = featureFlagsDisplayContextFactory;
 		_index = index;
@@ -98,7 +96,6 @@ public class FeatureFlagConfigurationScreen implements ConfigurationScreen {
 		}
 	}
 
-	private final FeatureFlagManager _featureFlagManager;
 	private final FeatureFlagsDisplayContextFactory
 		_featureFlagsDisplayContextFactory;
 	private final FeatureFlagType _featureFlagType;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-190240

Configuration screens are ordered based on the configuration screen key [here](https://github.com/liferay/liferay-portal/blob/6ce0b9eb049e99a50285a324a3bd4afd76d340ab/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationEntryRetrieverImpl.java#L383). By appending an index to the start of the key we are able to leverage this ordering to add the "Release" flags first. 

We are only concerned with the order of feature flags in the feature flags configuration, so I've isolated the changes here. The only downside of this is that it means that if we add a new feature flag type we need to add an update here as well.