### PR TITLE
LPS-196013 Set color for taglib-icon-help

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/taglib/_icon.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/taglib/_icon.scss
@@ -16,6 +16,15 @@
 	}
 }
 
+.taglib-icon-help {
+	color: $secondary !important;
+
+	&:hover,
+	&:active {
+		color: $dark !important;
+	}
+}
+
 .icon-monospaced {
 	color: inherit;
 	display: inline-block;


### PR DESCRIPTION
Issue https://liferay.atlassian.net/browse/LPS-196013 

Expected result for `liferay-ui:icon-help` icon
<img width="422" alt="LPS-196013" src="https://github.com/liferay-peds/liferay-portal/assets/8373764/b10c4036-6b33-411c-a826-8b643030d76e">

I made it work in most cases but not in the permission's modal. There is a style coming from Clay that I don't know how can be override. Could you please review it? 

```
.table-title[href]:hover,
.table-title [href]:hover {
  color: #212529;
}
```
Thank you very much! 

