### PR TITLE
LPS-197458 - The Sticky Search Bar in Site, Instance, and System Settings overlaps the Control Menu when Publications is enabled

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/search_results.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/search_results.jsp
@@ -33,7 +33,7 @@ portletDisplay.setURLBack(redirect);
 renderResponse.setTitle(LanguageUtil.get(request, "search-results"));
 %>
 
-<div class="sticky-top" style="top: 56px; z-index: 999;">
+<div class="sticky-top" style="top: var(--control-menu-container-height);">
 	<clay:management-toolbar
 		clearResultsURL="<%= redirect %>"
 		itemsTotal="<%= configurationEntryIterator.getTotal() %>"

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -20,7 +20,7 @@ ConfigurationScopeDisplayContext configurationScopeDisplayContext = Configuratio
 	<portlet:param name="redirect" value="<%= redirectURL %>" />
 </portlet:renderURL>
 
-<div class="sticky-top" style="top: 56px; z-index: 999;">
+<div class="sticky-top" style="top: var(--control-menu-container-height);">
 	<clay:management-toolbar
 		searchActionURL="<%= searchURL %>"
 		selectable="<%= false %>"

--- a/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
+++ b/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
@@ -1064,3 +1064,12 @@ html#{$cadmin-selector} {
 		position: static;
 	}
 }
+
+body {
+	/* stylelint-disable */
+	--control-menu-container-height: calc(
+		var(--change-tracking-indicator-height, 0px) +
+			var(--control-menu-height, 0px)
+	);
+	/* stylelint-enable */
+}

--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
@@ -274,3 +274,11 @@ html#{$cadmin-selector} {
 		}
 	}
 }
+
+.has-control-menu {	
+	--control-menu-height: 56px;
+
+	@include media-breakpoint-down(xs, $cadmin-grid-breakpoints) {
+		--control-menu-height: 48px;
+	}
+}

--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
@@ -275,7 +275,7 @@ html#{$cadmin-selector} {
 	}
 }
 
-.has-control-menu {	
+.has-control-menu {
 	--control-menu-height: 56px;
 
 	@include media-breakpoint-down(xs, $cadmin-grid-breakpoints) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-197458

> This PR initially fixes the sticky menu in Settings when publications is enabled. It also provides a new way of holistically handling this issue across all portal. in future PRs I will update "--control-menu-container-height" css variable to also handle the staging topbar created by Asset Libraries and then consistently apply this variable for all cases that require a fixed offset from admin topbars. This will require PRs to multiple other product teams which is why this will be handled in separate PRs.

Resending from #296, I fixed the SF issue and don't have push rights to @ethib137 repo.