### PR TITLE
LPS-194450 unlock dependent feature flags toggle

### DIFF
--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/jaxrs/application/FeatureFlagApplication.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/jaxrs/application/FeatureFlagApplication.java
@@ -5,9 +5,17 @@
 
 package com.liferay.feature.flag.web.internal.jaxrs.application;
 
+import com.liferay.feature.flag.web.internal.feature.flag.FeatureFlagsBag;
 import com.liferay.feature.flag.web.internal.feature.flag.FeatureFlagsBagProvider;
+import com.liferay.feature.flag.web.internal.model.FeatureFlagDisplay;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.feature.flag.FeatureFlag;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
@@ -18,6 +26,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.osgi.service.component.annotations.Component;
@@ -48,12 +57,60 @@ public class FeatureFlagApplication extends Application {
 
 		_featureFlagsBagProvider.setEnabled(companyId, key, enabled);
 
+		FeatureFlagsBag featureFlagsBag =
+			_featureFlagsBagProvider.getOrCreateFeatureFlagsBag(companyId);
+
 		return Response.ok(
+			HashMapBuilder.put(
+				"dependentFeatureFlags",
+				TransformUtil.transform(
+					_getDependentFeatureFlags(featureFlagsBag, key),
+					featureFlag -> _toMap(
+						companyId, featureFlag, featureFlagsBag))
+			).build(),
+			MediaType.APPLICATION_JSON
 		).build();
 	}
 
 	public Set<Object> getSingletons() {
 		return Collections.singleton(this);
+	}
+
+	private List<FeatureFlag> _getDependencyFeatureFlags(
+		FeatureFlagsBag featureFlagsBag, String key) {
+
+		FeatureFlag featureFlag = featureFlagsBag.getFeatureFlag(key);
+
+		return featureFlagsBag.getFeatureFlags(
+			maybeDependencyFeatureFlag -> ArrayUtil.contains(
+				featureFlag.getDependencyKeys(),
+				maybeDependencyFeatureFlag.getKey()));
+	}
+
+	private List<FeatureFlag> _getDependentFeatureFlags(
+		FeatureFlagsBag featureFlagsBag, String key) {
+
+		return featureFlagsBag.getFeatureFlags(
+			maybeDependentFeatureFlag -> ArrayUtil.contains(
+				maybeDependentFeatureFlag.getDependencyKeys(), key));
+	}
+
+	private Map<String, Object> _toMap(
+		long companyId, FeatureFlag featureFlag,
+		FeatureFlagsBag featureFlagsBag) {
+
+		FeatureFlagDisplay featureFlagDisplay = new FeatureFlagDisplay(
+			companyId,
+			_getDependencyFeatureFlags(featureFlagsBag, featureFlag.getKey()),
+			featureFlag, null);
+
+		return HashMapBuilder.<String, Object>put(
+			"disabled", !featureFlagDisplay.isDependenciesFulfilled()
+		).put(
+			"featureFlagKey", featureFlagDisplay.getKey()
+		).put(
+			"toggled", featureFlagDisplay.isEnabled()
+		).build();
 	}
 
 	@Reference

--- a/modules/apps/feature-flag/feature-flag-web/src/main/resources/META-INF/resources/js/FeatureFlagToggle.tsx
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/resources/META-INF/resources/js/FeatureFlagToggle.tsx
@@ -6,6 +6,14 @@
 import {ClayToggle} from '@clayui/form';
 import React, {useState} from 'react';
 
+import * as FeatureFlagToggleRegistry from './FeatureFlagToggleRegistry';
+
+interface IDependentFeatureFlag {
+	disabled: boolean;
+	featureFlagKey: string;
+	toggled: boolean;
+}
+
 interface IProps {
 	ariaDescribedBy: string;
 	companyId: number;
@@ -30,6 +38,18 @@ const FeatureFlagToggle = ({
 	const [disabled, setDisabled] = useState(initialDisabled);
 	const [toggled, setToggled] = useState(initialToggled);
 
+	FeatureFlagToggleRegistry.registerToggle(
+		featureFlagKey,
+		(newToggled: boolean, newDisabled: boolean) => {
+			if (toggled !== newToggled) {
+				setToggled(newToggled);
+			}
+			if (disabled !== newDisabled) {
+				setDisabled(newDisabled);
+			}
+		}
+	);
+
 	async function updateToggled(newToggled: boolean) {
 		setDisabled(true);
 
@@ -46,16 +66,27 @@ const FeatureFlagToggle = ({
 				}
 			);
 
-			if (response.ok) {
-				setToggled(newToggled);
-			}
-			else {
+			if (!response.ok) {
 				Liferay.Util.openToast({
 					message: Liferay.Language.get(
 						'could-not-update-feature-flag'
 					),
 					type: 'danger',
 				});
+
+				return;
+			}
+
+			setToggled(newToggled);
+
+			const json = await response.json();
+
+			for (const dependency of json.dependentFeatureFlags as IDependentFeatureFlag[]) {
+				FeatureFlagToggleRegistry.updateToggle(
+					dependency.featureFlagKey,
+					dependency.toggled,
+					dependency.disabled
+				);
 			}
 		}
 		finally {

--- a/modules/apps/feature-flag/feature-flag-web/src/main/resources/META-INF/resources/js/FeatureFlagToggleRegistry.ts
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/resources/META-INF/resources/js/FeatureFlagToggleRegistry.ts
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+type UpdateFunction = (toggled: boolean, disabled: boolean) => void;
+const toggles: {[featureFlagKey: string]: UpdateFunction} = {};
+
+export function registerToggle(
+	featureFlagKey: string,
+	updateFunction: UpdateFunction
+) {
+	toggles[featureFlagKey] = updateFunction;
+}
+
+export function updateToggle(
+	featureFlagKey: string,
+	toggled: boolean,
+	disabled: boolean
+) {
+	const updateFunction = toggles[featureFlagKey];
+
+	if (updateFunction) {
+		updateFunction(toggled, disabled);
+	}
+}

--- a/modules/apps/feature-flag/feature-flag-web/types/src/main/resources/META-INF/resources/js/FeatureFlagToggleRegistry.d.ts
+++ b/modules/apps/feature-flag/feature-flag-web/types/src/main/resources/META-INF/resources/js/FeatureFlagToggleRegistry.d.ts
@@ -1,0 +1,16 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+declare type UpdateFunction = (toggled: boolean, disabled: boolean) => void;
+export declare function registerToggle(
+	featureFlagKey: string,
+	updateFunction: UpdateFunction
+): void;
+export declare function updateToggle(
+	featureFlagKey: string,
+	toggled: boolean,
+	disabled: boolean
+): void;
+export {};


### PR DESCRIPTION
Ticket [LPS-194450](https://liferay.atlassian.net/browse/LPS-194450)

Issue
=======
The dependent feature flags in the feature flags configuration page were not having their toggle unlocked/locked based on their dependencies status.

Example:

LPS-123
LPS-456 which depends on LPS-123

Considering LPS-123 disabled, LPS-456 toggle switch would be locked. After enabling the LPS-123, the LPS-456 toggle switch should be unlocked, but it wasn't. It was required to reload the page.

Proposed Solution
========
Drew Brokke proposed the solution: 

have a JS variable which holds the toggles and updates their states (locked/unlocked) based on the feature flags activation/deactivation.

Alternative Solutions that was discarded
========
I thought that creating an entire rest api was necessary, it wasn't. Feature flags only have one endpoint, and it's simple, would be a lot of changes for a small fix.
