### PR TITLE
LPS-198287 Set overflow visible to avoid double scroll in a line

### DIFF
--- a/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
+++ b/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
@@ -383,6 +383,7 @@ html#{$cadmin-selector} {
 			pre.CodeMirror-line-like {
 				font-family: inherit;
 				margin: 0;
+				overflow: visible;
 				padding: 0 4px;
 				white-space: pre;
 			}


### PR DESCRIPTION
Hi guys!

In Echo team we have these two issues https://liferay.atlassian.net/browse/LPS-198287 and https://liferay.atlassian.net/browse/LPS-198284. These issues are related to the Code Mirror classes in cadmin. Could you review this change? 

Thanks in advance!