### PR TITLE
LPS-198267 Avoid setting style when it is a beta button

### DIFF
--- a/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/_sidebar.scss
+++ b/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/_sidebar.scss
@@ -64,7 +64,7 @@ html#{$cadmin-selector} {
 			}
 
 			.btn {
-				&:not(.btn-unstyled) {
+				&:not(.btn-unstyled, .btn-beta) {
 					border-radius: 3px;
 					font-size: 14px;
 					line-height: 1.15;


### PR DESCRIPTION
Hi guys!

From the Echo team we discovered this issue (https://liferay.atlassian.net/browse/LPS-198267) when adding a Beta button in a panel (with class `.sidebar-sm`). Here I send you the fix, could you review it?

Thank in advance!