### PR TITLE
LPS-193598 Add Autom. Test ClayAccessibilty#AccessibilitySmoke

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAccessibility.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAccessibility.testcase
@@ -5,7 +5,7 @@ definition {
 	property portal.accessibility = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";
-	property testray.component.names = "Clay";
+	property testray.component.names = "PEDS Accessibility";
 	property testray.main.component.name = "Clay";
 
 	setUp {
@@ -45,7 +45,7 @@ definition {
 		}
 	}
 
-	@description = "LPS-193598. Verifies that clay portlet tabs are accessible."
+	@description = "LPS-193598. Verifies clay sample portlet components are compliant with axe accessibility."
 	@priority = 5
 	test AccessibilitySmoke {
 		task ("When access all clay sample portlet tabs ") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAccessibility.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAccessibility.testcase
@@ -1,0 +1,68 @@
+@component-name = "portal-frontend-infrastructure"
+definition {
+
+	property osgi.modules.includes = "frontend-taglib-clay-sample-web";
+	property portal.accessibility = "true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Clay";
+	property testray.main.component.name = "Clay";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		task ("Given Clay Sample Portlet") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page");
+
+			JSONLayout.updateLayoutTemplateOfPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page",
+				layoutTemplate = "1 Column");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page",
+				widgetName = "Clay Sample");
+
+			Navigator.gotoPage(pageName = "Clay Sample Test Page");
+		}
+	}
+
+	tearDown {
+		var testLiferayVirtualInstance = PropsUtil.get("test.liferay.virtual.instance");
+
+		if (${testLiferayVirtualInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			JSONLayout.deletePublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page");
+		}
+	}
+
+	@description = "LPS-193598. Verifies that clay portlet tabs are accessible."
+	@priority = 5
+	test AccessibilitySmoke {
+		task ("When access all clay sample portlet tabs ") {
+			for (var key_tab : list "Alerts,Badges,Dropdowns,Icons,Labels,Links,Management Toolbars,Navigation Bars,Stickers,Tabs") {
+				Click(
+					key_tab = ${key_tab},
+					locator1 = "NavTab#NAV_TABS");
+
+				task ("Then axe automation finds no accessibility issues") {
+					AssertAccessible(value1 = "moderate,minor");
+
+					// The other tabs will be included after LPS-198580 is done
+					// Buttons,Cards,Form Elements,Pagination Bars,Panel,Progress Bars,Vertical Nav
+
+				}
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
[Ticket](https://liferay.atlassian.net/browse/LPS-193598)

Given new content page 
And Clay Sample Portlet 
When access all clay sample portlet tabs 
Then axe automation finds no accessibility issues
// use poshi function AssertAccessible

Some tabs were taken out by the test intentionally. They will be included when [LPS-198580](https://liferay.atlassian.net/browse/LPS-198580) is done.